### PR TITLE
Fix pivot positioning and add tests

### DIFF
--- a/core/puppet_model.py
+++ b/core/puppet_model.py
@@ -122,7 +122,11 @@ class Puppet:
                     continue
             bbox = svg_loader.get_group_bounding_box(group_id) or (0, 0, 0, 0)
             pivot_group = pivot_map[group_id] if pivot_map and group_id in pivot_map else group_id
-            pivot = svg_loader.get_pivot(pivot_group)
+            pivot_global = svg_loader.get_pivot(pivot_group)
+            pivot = (
+                pivot_global[0] - bbox[0],
+                pivot_global[1] - bbox[1],
+            )
             z_order = z_order_map.get(group_id, 0) if z_order_map else 0
             self.members[group_id] = PuppetMember(group_id, None, pivot, bbox, z_order)
         for child, parent in parent_map.items():

--- a/core/svg_loader.py
+++ b/core/svg_loader.py
@@ -46,9 +46,21 @@ class SvgLoader:
         return (rect.left(), rect.top(), rect.right(), rect.bottom())
 
     def get_pivot(self, group_id):
+        """Return the pivot point of ``group_id``.
+
+        If the group contains a circle/ellipse, their center is used;
+        otherwise, fall back to the center of the group's bounding box.
         """
-        Retourne le centre de la bbox du groupe (pour les groupes pivot).
-        """
+        group_elem = self.root.find(f".//svg:g[@id='{group_id}']", self.namespaces)
+        if group_elem is not None:
+            for tag in ("circle", "ellipse"):
+                shape = group_elem.find(f"svg:{tag}", self.namespaces)
+                if shape is not None and "cx" in shape.attrib and "cy" in shape.attrib:
+                    try:
+                        return float(shape.attrib["cx"]), float(shape.attrib["cy"])
+                    except ValueError:
+                        pass
+
         bbox = self.get_group_bounding_box(group_id)
         if bbox is None:
             return 0, 0

--- a/tests/test_pivots.py
+++ b/tests/test_pivots.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.svg_loader import SvgLoader
+from core.puppet_model import Puppet, PARENT_MAP, PIVOT_MAP
+
+
+def compute_expected_local(loader, group_id, pivot_group):
+    bbox = loader.get_group_bounding_box(group_id)
+    pivot_global = loader.get_pivot(pivot_group)
+    return (
+        pivot_global[0] - bbox[0],
+        pivot_global[1] - bbox[1],
+    )
+
+
+def test_coude_droite_pivot():
+    loader = SvgLoader("assets/wesh.svg")
+    puppet = Puppet()
+    puppet.build_from_svg(loader, PARENT_MAP, PIVOT_MAP)
+    expected = compute_expected_local(loader, "coude_droite", "coude_droite")
+    assert puppet.members["coude_droite"].pivot == pytest.approx(expected)
+
+
+def test_haut_bras_droite_pivot():
+    loader = SvgLoader("assets/wesh.svg")
+    puppet = Puppet()
+    puppet.build_from_svg(loader, PARENT_MAP, PIVOT_MAP)
+    expected = compute_expected_local(loader, "haut_bras_droite", "epaule_droite")
+    assert puppet.members["haut_bras_droite"].pivot == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- ensure pivot coordinates are computed relative to each piece's bounding box
- detect circle/ellipse centers when available instead of bounding box centers
- add unit tests validating pivot placement

## Testing
- `python -m core.puppet_model`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e16afa0c832b9df9e82609764eef