### PR TITLE
Fix puppet pivot offsets and add tests

### DIFF
--- a/tests/test_pivots.py
+++ b/tests/test_pivots.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+# Ensure Qt runs in offscreen mode
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from core.svg_loader import SvgLoader
+from core.puppet_model import Puppet, PARENT_MAP, PIVOT_MAP, Z_ORDER
+from core.puppet_piece import PuppetPiece
+
+
+def setup_module(module):
+    # Create a QApplication if not already existing
+    module.app = QApplication.instance() or QApplication(sys.argv)
+
+
+def test_pivots_are_positioned_correctly():
+    loader = SvgLoader("assets/wesh.svg")
+    puppet = Puppet()
+    puppet.build_from_svg(loader, PARENT_MAP, PIVOT_MAP, Z_ORDER)
+
+    for name, member in puppet.members.items():
+        offset = loader.get_group_offset(name) or (0, 0)
+        pivot_x = member.pivot[0] - offset[0]
+        pivot_y = member.pivot[1] - offset[1]
+        target_pivot_x, target_pivot_y = puppet.get_handle_target_pivot(name)
+        if target_pivot_x is not None and target_pivot_y is not None:
+            target_pivot_x -= offset[0]
+            target_pivot_y -= offset[1]
+        piece = PuppetPiece(
+            "assets/wesh.svg",
+            name,
+            pivot_x=pivot_x,
+            pivot_y=pivot_y,
+            target_pivot_x=target_pivot_x,
+            target_pivot_y=target_pivot_y,
+            renderer=loader.renderer,
+            grid=None,
+        )
+        piece.setPos(offset[0], offset[1])
+        scene_pivot = piece.mapToScene(piece.transformOriginPoint())
+        assert scene_pivot.x() == pytest.approx(member.pivot[0])
+        assert scene_pivot.y() == pytest.approx(member.pivot[1])

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -48,11 +48,19 @@ class MainWindow(QMainWindow):
 
     def _add_puppet_graphics(self, puppet_name, puppet, file_path, renderer, loader):
         for name, member in puppet.members.items():
+            offset = loader.get_group_offset(name) or (0, 0)
+            pivot_x = member.pivot[0] - offset[0]
+            pivot_y = member.pivot[1] - offset[1]
             target_pivot_x, target_pivot_y = puppet.get_handle_target_pivot(name)
+            if target_pivot_x is not None and target_pivot_y is not None:
+                target_pivot_x -= offset[0]
+                target_pivot_y -= offset[1]
+
             piece = PuppetPiece(
-                file_path, name,
-                pivot_x=member.pivot[0],
-                pivot_y=member.pivot[1],
+                file_path,
+                name,
+                pivot_x=pivot_x,
+                pivot_y=pivot_y,
                 target_pivot_x=target_pivot_x,
                 target_pivot_y=target_pivot_y,
                 renderer=renderer,
@@ -60,7 +68,6 @@ class MainWindow(QMainWindow):
             )
             piece.setZValue(member.z_order)
             self.scene.addItem(piece)
-            offset = loader.get_group_offset(name) or (0, 0)
             piece.setPos(offset[0], offset[1])
             self.graphics_items[f"{puppet_name}:{name}"] = piece
 


### PR DESCRIPTION
## Summary
- adjust pivot computations to account for group offsets so joints align correctly
- add unit test ensuring pivot positions match expected locations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e16afa0c832b9df9e82609764eef