### PR TITLE
Fix SVG pivot positions and add tests

### DIFF
--- a/core/puppet_model.py
+++ b/core/puppet_model.py
@@ -121,8 +121,10 @@ class Puppet:
             if group_id not in parent_map:
                     continue
             bbox = svg_loader.get_group_bounding_box(group_id) or (0, 0, 0, 0)
+            x_min, y_min, _, _ = bbox
             pivot_group = pivot_map[group_id] if pivot_map and group_id in pivot_map else group_id
-            pivot = svg_loader.get_pivot(pivot_group)
+            pivot_global = svg_loader.get_pivot(pivot_group)
+            pivot = (pivot_global[0] - x_min, pivot_global[1] - y_min)
             z_order = z_order_map.get(group_id, 0) if z_order_map else 0
             self.members[group_id] = PuppetMember(group_id, None, pivot, bbox, z_order)
         for child, parent in parent_map.items():

--- a/tests/test_pivots.py
+++ b/tests/test_pivots.py
@@ -1,0 +1,37 @@
+import unittest
+
+from core.svg_loader import SvgLoader
+from core.puppet_model import Puppet, PARENT_MAP, PIVOT_MAP, Z_ORDER
+
+PIVOT_IDS = [
+    "coude_droite",
+    "coude_gauche",
+    "epaule_droite",
+    "epaule_gauche",
+    "cou",
+    "genou_droite",
+    "genou_gauche",
+    "hanche_droite",
+    "hanche_gauche",
+]
+
+
+class PivotPositionTests(unittest.TestCase):
+    def test_pivots_relative_to_group(self):
+        loader = SvgLoader("assets/wesh.svg")
+        puppet = Puppet()
+        puppet.build_from_svg(loader, PARENT_MAP, PIVOT_MAP, Z_ORDER)
+        for name in PIVOT_IDS:
+            with self.subTest(member=name):
+                member = puppet.members.get(name)
+                self.assertIsNotNone(member, f"Member {name} should exist")
+                pivot_group = PIVOT_MAP.get(name, name)
+                pivot_global = loader.get_pivot(pivot_group)
+                offset = loader.get_group_offset(name) or (0, 0)
+                expected = (pivot_global[0] - offset[0], pivot_global[1] - offset[1])
+                self.assertAlmostEqual(member.pivot[0], expected[0], places=2)
+                self.assertAlmostEqual(member.pivot[1], expected[1], places=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute pivots relative to each group bounding box to avoid misaligned rotation centers
- add unit tests validating pivot positions for all key joints in the SVG

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6893e16afa0c832b9df9e82609764eef