### PR TITLE
Fix pivot placement by using local coordinates and add tests

### DIFF
--- a/tests/test_pivots.py
+++ b/tests/test_pivots.py
@@ -1,0 +1,39 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from ui.main_window import MainWindow
+from core.svg_loader import SvgLoader
+
+PIVOTS = [
+    "coude_droite",
+    "coude_gauche",
+    "epaule_droite",
+    "epaule_gauche",
+    "cou",
+    "genou_droite",
+    "genou_gauche",
+    "hanche_droite",
+    "hanche_gauche",
+]
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_pivot_alignment(app):
+    window = MainWindow()
+    loader = SvgLoader("assets/wesh.svg")
+    for pivot_id in PIVOTS:
+        piece = window.graphics_items[f"manu:{pivot_id}"]
+        global_pivot = loader.get_pivot(pivot_id)
+        mapped = piece.mapToScene(piece.transformOriginPoint())
+        assert mapped.x() == pytest.approx(global_pivot[0])
+        assert mapped.y() == pytest.approx(global_pivot[1])


### PR DESCRIPTION
## Summary
- convert global pivot coordinates to local ones when creating puppet graphics so rotation centers align with group geometry
- add regression tests ensuring pivot groups (elbows, shoulders, neck, knees, hips) map correctly to scene coordinates

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e16afa0c832b9df9e82609764eef