### PR TITLE
Fix puppet pivot placement and linkage

### DIFF
--- a/tests/test_puppet_graphics.py
+++ b/tests/test_puppet_graphics.py
@@ -1,0 +1,62 @@
+import os
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+from PySide6.QtWidgets import QApplication, QGraphicsItem
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ui.main_window import MainWindow
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_hierarchy_and_pivot(app):
+    window = MainWindow()
+
+    upper = window.graphics_items["manu:haut_bras_droite"]
+    elbow = window.graphics_items["manu:coude_droite"]
+    forearm = window.graphics_items["manu:avant_bras_droite"]
+
+    # Vérifie la hiérarchie parent/enfant
+    assert forearm.parentItem() is elbow
+    assert elbow.parentItem() is upper
+
+    # Pivots superposés avant rotation
+    elbow_pos = elbow.mapToScene(elbow.transformOriginPoint())
+    forearm_pos = forearm.mapToScene(forearm.transformOriginPoint())
+    assert elbow_pos.x() == pytest.approx(forearm_pos.x())
+    assert elbow_pos.y() == pytest.approx(forearm_pos.y())
+
+    # Après rotation du bras, le coude et l\'avant-bras restent solidaires
+    upper.setRotation(45)
+    elbow_pos_after = elbow.mapToScene(elbow.transformOriginPoint())
+    forearm_pos_after = forearm.mapToScene(forearm.transformOriginPoint())
+    assert elbow_pos_after.x() == pytest.approx(forearm_pos_after.x())
+    assert elbow_pos_after.y() == pytest.approx(forearm_pos_after.y())
+
+
+def test_z_order_independent_from_hierarchy(app):
+    window = MainWindow()
+
+    thigh = window.graphics_items["manu:cuisse_droite"]
+    torso = window.graphics_items["manu:torse"]
+    shoulder = window.graphics_items["manu:epaule_droite"]
+
+    # La cuisse est derrière son parent et le torse
+    assert thigh.flags() & QGraphicsItem.ItemStacksBehindParent
+    assert thigh.zValue() < torso.zValue()
+
+    # L'épaule reste devant le torse sans drapeau particulier
+    assert not (shoulder.flags() & QGraphicsItem.ItemStacksBehindParent)
+    assert shoulder.zValue() > torso.zValue()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QMainWindow, QGraphicsView, QGraphicsScene, QVBoxLayout,
-    QWidget, QGraphicsPixmapItem, QGraphicsEllipseItem
+    QWidget, QGraphicsPixmapItem, QGraphicsEllipseItem, QGraphicsItem
 )
 from PySide6.QtGui import QPainter, QPixmap, QPen, QColor
 from PySide6.QtCore import Qt
@@ -47,22 +47,56 @@ class MainWindow(QMainWindow):
         self._fit_scene_to_svg(loader)
 
     def _add_puppet_graphics(self, puppet_name, puppet, file_path, renderer, loader):
+        # Pré-calcul des offsets de chaque groupe
+        offsets = {
+            name: loader.get_group_offset(name) or (0, 0)
+            for name in puppet.members
+        }
+
+        # Création des pièces du pantin
+        pieces = {}
         for name, member in puppet.members.items():
+            offset_x, offset_y = offsets[name]
+
+            # Pivot local relatif à l'origine de l'item
+            pivot_x = member.pivot[0] - offset_x
+            pivot_y = member.pivot[1] - offset_y
+
+            # Direction du handle : convertie aussi dans le repère local
             target_pivot_x, target_pivot_y = puppet.get_handle_target_pivot(name)
+            if target_pivot_x is not None and target_pivot_y is not None:
+                target_pivot_x -= offset_x
+                target_pivot_y -= offset_y
+
             piece = PuppetPiece(
-                file_path, name,
-                pivot_x=member.pivot[0],
-                pivot_y=member.pivot[1],
+                file_path,
+                name,
+                pivot_x=pivot_x,
+                pivot_y=pivot_y,
                 target_pivot_x=target_pivot_x,
                 target_pivot_y=target_pivot_y,
                 renderer=renderer,
                 grid=None,
             )
             piece.setZValue(member.z_order)
-            self.scene.addItem(piece)
-            offset = loader.get_group_offset(name) or (0, 0)
-            piece.setPos(offset[0], offset[1])
+            pieces[name] = piece
             self.graphics_items[f"{puppet_name}:{name}"] = piece
+
+        # Construction de la hiérarchie des items
+        for name, piece in pieces.items():
+            member = puppet.members[name]
+            offset_x, offset_y = offsets[name]
+            if member.parent:
+                parent_piece = pieces[member.parent.name]
+                parent_offset_x, parent_offset_y = offsets[member.parent.name]
+                piece.setParentItem(parent_piece)
+                if member.z_order < member.parent.z_order:
+                    piece.setFlag(QGraphicsItem.ItemStacksBehindParent)
+                # Position relative au parent
+                piece.setPos(offset_x - parent_offset_x, offset_y - parent_offset_y)
+            else:
+                self.scene.addItem(piece)
+                piece.setPos(offset_x, offset_y)
 
     def _fit_scene_to_svg(self, loader):
         if hasattr(loader, "get_svg_viewbox"):


### PR DESCRIPTION
## Summary
- compute pivot coordinates relative to their group bounding boxes
- attach puppet pieces according to skeleton hierarchy to avoid dislocation
- preserve manual z-order by stacking limbs behind parents when their z-value is lower
- add regression tests ensuring joints stay attached and layering is unaffected

## Testing
- `pip install -r requirements.txt`
- `apt-get update`
- `apt-get install -y libgl1 libgl1-mesa-dri libxkbcommon0 libegl1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e9132ba0832b8a6021644cb44b96