### PR TITLE
Fix puppet pivot placement and linkage

### DIFF
--- a/tests/test_puppet_graphics.py
+++ b/tests/test_puppet_graphics.py
@@ -1,0 +1,63 @@
+import os
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+from PySide6.QtWidgets import QApplication
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ui.main_window import MainWindow
+from core.puppet_model import Z_ORDER
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_hierarchy_and_pivot(app):
+    window = MainWindow()
+
+    upper = window.graphics_items["manu:haut_bras_droite"]
+    elbow = window.graphics_items["manu:coude_droite"]
+    forearm = window.graphics_items["manu:avant_bras_droite"]
+
+    # Vérifie la hiérarchie parent/enfant
+    assert forearm.parentItem() is elbow
+    assert elbow.parentItem() is upper
+
+    # Pivots superposés avant rotation
+    elbow_pos = elbow.mapToScene(elbow.transformOriginPoint())
+    forearm_pos = forearm.mapToScene(forearm.transformOriginPoint())
+    assert elbow_pos.x() == pytest.approx(forearm_pos.x())
+    assert elbow_pos.y() == pytest.approx(forearm_pos.y())
+
+    # Après rotation du bras, le coude et l\'avant-bras restent solidaires
+    upper.setRotation(45)
+    elbow_pos_after = elbow.mapToScene(elbow.transformOriginPoint())
+    forearm_pos_after = forearm.mapToScene(forearm.transformOriginPoint())
+    assert elbow_pos_after.x() == pytest.approx(forearm_pos_after.x())
+    assert elbow_pos_after.y() == pytest.approx(forearm_pos_after.y())
+
+
+def test_z_order_preserved(app):
+    window = MainWindow()
+
+    def effective_z(item):
+        z = 0
+        current = item
+        while current is not None:
+            z += current.zValue()
+            current = current.parentItem()
+        return z
+
+    for name, expected in Z_ORDER.items():
+        item = window.graphics_items[f"manu:{name}"]
+        assert effective_z(item) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- compute pivot coordinates relative to their group bounding boxes
- attach puppet pieces according to skeleton hierarchy to avoid dislocation
- compute z-values relative to parent to keep manual draw order
- add regression tests verifying joints stay attached and z-order is respected

## Testing
- `pip install -r requirements.txt`
- `apt-get update`
- `apt-get install -y libgl1 libgl1-mesa-dri libxkbcommon0 libegl1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e9132ba0832b8a6021644cb44b96