### PR TITLE
Optimize transformations and SVG path regex compilation

### DIFF
--- a/core/puppet_piece.py
+++ b/core/puppet_piece.py
@@ -100,15 +100,18 @@ class PuppetPiece(QGraphicsSvgItem):
             return
 
         parent = self.parent_piece
-        angle_rad = math.radians(parent.rotation())
+        parent_rotation = parent.rotation()
+        angle_rad = math.radians(parent_rotation)
         dx, dy = self.rel_to_parent
-        rotated_dx = dx * math.cos(angle_rad) - dy * math.sin(angle_rad)
-        rotated_dy = dx * math.sin(angle_rad) + dy * math.cos(angle_rad)
+        cos_a = math.cos(angle_rad)
+        sin_a = math.sin(angle_rad)
+        rotated_dx = dx * cos_a - dy * sin_a
+        rotated_dy = dx * sin_a + dy * cos_a
         parent_pivot = parent.mapToScene(parent.transformOriginPoint())
         scene_x = parent_pivot.x() + rotated_dx
         scene_y = parent_pivot.y() + rotated_dy
         self.setPos(scene_x - self.pivot_x, scene_y - self.pivot_y)
-        self.setRotation(parent.rotation() + self.local_rotation)
+        self.setRotation(parent_rotation + self.local_rotation)
         for child in self.children:
             child.update_transform_from_parent()
 

--- a/core/svg_loader.py
+++ b/core/svg_loader.py
@@ -7,6 +7,11 @@ from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtCore import QRectF
 
 
+_COORD_PATTERN = re.compile(
+    r"((?:[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?\s*)+)"
+)
+
+
 class SvgLoader:
     def __init__(self, svg_path: str) -> None:
         self.svg_path = svg_path
@@ -130,8 +135,4 @@ def translate_path(d, dx, dy):
                 new_nums.append(n)
         return " ".join(new_nums)
 
-    return re.sub(
-        r"((?:[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?\s*)+)",
-        repl,
-        d
-    )
+    return _COORD_PATTERN.sub(repl, d)


### PR DESCRIPTION
## Summary
- avoid redundant trigonometric calls in `PuppetPiece.update_transform_from_parent`
- precompile regex for SVG path translation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894d6f23fb4832b9f11f17ff522f148