### PR TITLE
Enable movable puppet across scene

### DIFF
--- a/core/puppet_piece.py
+++ b/core/puppet_piece.py
@@ -53,6 +53,7 @@ class PuppetPiece(QGraphicsSvgItem):
         self.target_pivot_y = float(target_pivot_y) if target_pivot_y is not None else None
         self.grid = grid
         self.setTransformOriginPoint(self.pivot_x, self.pivot_y)
+        self.setFlag(QGraphicsItem.ItemSendsGeometryChanges)
 
         # Chaînage logique sans dépendre de QGraphicsItem
         self.parent_piece = None
@@ -87,6 +88,10 @@ class PuppetPiece(QGraphicsSvgItem):
         # Z-value du handle quand la pièce est ajoutée à la scène
         if change == QGraphicsItem.ItemSceneHasChanged and self.rotation_handle:
             self.rotation_handle.setZValue(self.zValue() + 1)
+        # Déplacement du membre : tous les enfants suivent
+        if change == QGraphicsItem.ItemPositionHasChanged:
+            for child in self.children:
+                child.update_transform_from_parent()
         return super().itemChange(change, value)
 
     def set_parent_piece(self, parent, rel_x=0.0, rel_y=0.0):

--- a/tests/test_puppet_graphics.py
+++ b/tests/test_puppet_graphics.py
@@ -47,3 +47,20 @@ def test_hierarchy_and_pivot(app):
 
     # L'ordre d'affichage reste celui défini manuellement
     assert upper.zValue() == -1
+
+
+def test_move_puppet(app):
+    window = MainWindow()
+    from PySide6.QtWidgets import QGraphicsItem
+    torso = window.graphics_items["manu:torse"]
+    arm = window.graphics_items["manu:haut_bras_droite"]
+
+    assert torso.flags() & QGraphicsItem.ItemIsMovable
+
+    arm_before = arm.mapToScene(arm.transformOriginPoint())
+    torso.setPos(torso.pos().x() + 40, torso.pos().y() + 25)
+    app.processEvents()
+    arm_after = arm.mapToScene(arm.transformOriginPoint())
+
+    assert arm_after.x() == pytest.approx(arm_before.x() + 40)
+    assert arm_after.y() == pytest.approx(arm_before.y() + 25)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QMainWindow, QGraphicsView, QGraphicsScene, QVBoxLayout,
-    QWidget, QGraphicsPixmapItem
+    QWidget, QGraphicsPixmapItem, QGraphicsItem
 )
 from PySide6.QtGui import QPainter, QPixmap
 from PySide6.QtCore import Qt
@@ -82,6 +82,8 @@ class MainWindow(QMainWindow):
                 grid=None,
             )
             piece.setZValue(member.z_order)
+            if member.parent is None:
+                piece.setFlag(QGraphicsItem.ItemIsMovable, True)
             pieces[name] = piece
             self.graphics_items[f"{puppet_name}:{name}"] = piece
 


### PR DESCRIPTION
## Summary
- Allow root puppet pieces to be dragged around the scene
- Propagate parent movement to children via geometry change notifications
- Test puppet translation to ensure limbs follow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894db33858c832bb5c303b380a2cec9