### PR TITLE
Allow puppet to move across the scene

### DIFF
--- a/core/puppet_piece.py
+++ b/core/puppet_piece.py
@@ -87,7 +87,12 @@ class PuppetPiece(QGraphicsSvgItem):
         # Z-value du handle quand la pièce est ajoutée à la scène
         if change == QGraphicsItem.ItemSceneHasChanged and self.rotation_handle:
             self.rotation_handle.setZValue(self.zValue() + 1)
-        return super().itemChange(change, value)
+        result = super().itemChange(change, value)
+        # Propagation de la translation aux enfants
+        if change == QGraphicsItem.ItemPositionHasChanged:
+            for child in self.children:
+                child.update_transform_from_parent()
+        return result
 
     def set_parent_piece(self, parent, rel_x=0.0, rel_y=0.0):
         self.parent_piece = parent

--- a/tests/test_puppet_graphics.py
+++ b/tests/test_puppet_graphics.py
@@ -2,7 +2,7 @@ import os
 
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QGraphicsItem
 import pytest
 
 import sys
@@ -47,3 +47,25 @@ def test_hierarchy_and_pivot(app):
 
     # L'ordre d'affichage reste celui défini manuellement
     assert upper.zValue() == -1
+
+
+def test_puppet_translation_moves_children(app):
+    window = MainWindow()
+
+    torso = window.graphics_items["manu:torse"]
+    elbow = window.graphics_items["manu:coude_droite"]
+
+    # Le torse peut être déplacé
+    assert torso.flags() & QGraphicsItem.ItemIsMovable
+
+    torso_pivot_before = torso.mapToScene(torso.transformOriginPoint())
+    elbow_pivot_before = elbow.mapToScene(elbow.transformOriginPoint())
+    dx_before = elbow_pivot_before.x() - torso_pivot_before.x()
+    dy_before = elbow_pivot_before.y() - torso_pivot_before.y()
+
+    torso.setPos(torso.x() + 50, torso.y() + 20)
+
+    torso_pivot_after = torso.mapToScene(torso.transformOriginPoint())
+    elbow_pivot_after = elbow.mapToScene(elbow.transformOriginPoint())
+    assert elbow_pivot_after.x() - torso_pivot_after.x() == pytest.approx(dx_before)
+    assert elbow_pivot_after.y() - torso_pivot_after.y() == pytest.approx(dy_before)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QMainWindow, QGraphicsView, QGraphicsScene, QVBoxLayout,
-    QWidget, QGraphicsPixmapItem
+    QWidget, QGraphicsPixmapItem, QGraphicsItem
 )
 from PySide6.QtGui import QPainter, QPixmap
 from PySide6.QtCore import Qt
@@ -82,6 +82,9 @@ class MainWindow(QMainWindow):
                 grid=None,
             )
             piece.setZValue(member.z_order)
+            if member.parent is None:
+                piece.setFlag(QGraphicsItem.ItemIsMovable)
+                piece.setFlag(QGraphicsItem.ItemSendsGeometryChanges)
             pieces[name] = piece
             self.graphics_items[f"{puppet_name}:{name}"] = piece
 


### PR DESCRIPTION
## Summary
- propagate root piece translation to dependent limbs
- make root puppet piece movable and emit geometry changes
- test that moving the puppet drags all children

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894db33858c832bb5c303b380a2cec9