### PR TITLE
Enable full-scene puppet movement

### DIFF
--- a/core/puppet_piece.py
+++ b/core/puppet_piece.py
@@ -81,6 +81,9 @@ class PuppetPiece(QGraphicsSvgItem):
         # Magnétisme à la grille
         if change == QGraphicsItem.ItemPositionChange and self.scene() and self.grid:
             return self.grid.snap_to_grid(value)
+        if change == QGraphicsItem.ItemPositionHasChanged:
+            for child in self.children:
+                child.update_transform_from_parent()
         # Z-value du handle quand l'item change de Z
         if change == QGraphicsItem.ItemZValueHasChanged and self.rotation_handle:
             self.rotation_handle.setZValue(value + 1)

--- a/tests/test_puppet_graphics.py
+++ b/tests/test_puppet_graphics.py
@@ -2,7 +2,7 @@ import os
 
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QGraphicsItem
 import pytest
 
 import sys
@@ -47,3 +47,19 @@ def test_hierarchy_and_pivot(app):
 
     # L'ordre d'affichage reste celui défini manuellement
     assert upper.zValue() == -1
+
+
+def test_puppet_translation(app):
+    window = MainWindow()
+    torso = window.graphics_items["manu:torse"]
+    hand = window.graphics_items["manu:main_droite"]
+
+    # Le torse doit être déplaçable
+    assert torso.flags() & QGraphicsItem.ItemIsMovable
+
+    original = hand.mapToScene(hand.transformOriginPoint())
+    torso.setPos(torso.x() + 50, torso.y() + 20)
+    moved = hand.mapToScene(hand.transformOriginPoint())
+
+    assert moved.x() == pytest.approx(original.x() + 50)
+    assert moved.y() == pytest.approx(original.y() + 20)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,6 +1,11 @@
 from PySide6.QtWidgets import (
-    QMainWindow, QGraphicsView, QGraphicsScene, QVBoxLayout,
-    QWidget, QGraphicsPixmapItem
+    QMainWindow,
+    QGraphicsView,
+    QGraphicsScene,
+    QVBoxLayout,
+    QWidget,
+    QGraphicsPixmapItem,
+    QGraphicsItem,
 )
 from PySide6.QtGui import QPainter, QPixmap
 from PySide6.QtCore import Qt
@@ -97,6 +102,8 @@ class MainWindow(QMainWindow):
                 piece.set_parent_piece(parent_piece, rel_x, rel_y)
             else:
                 piece.setPos(offset_x, offset_y)
+                piece.setFlag(QGraphicsItem.ItemIsMovable, True)
+                piece.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
 
         # Ajout des items à la scène
         for piece in pieces.values():


### PR DESCRIPTION
## Summary
- Make root puppet pieces movable across the scene
- Propagate translations to children to keep hierarchy coherent
- Test that moving the torso drags attached limbs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894db33858c832bb5c303b380a2cec9