### PR TITLE
Allow puppet to move across scene

### DIFF
--- a/core/puppet_piece.py
+++ b/core/puppet_piece.py
@@ -87,6 +87,10 @@ class PuppetPiece(QGraphicsSvgItem):
         # Z-value du handle quand la pièce est ajoutée à la scène
         if change == QGraphicsItem.ItemSceneHasChanged and self.rotation_handle:
             self.rotation_handle.setZValue(self.zValue() + 1)
+        # Propagation du déplacement aux enfants
+        if change == QGraphicsItem.ItemPositionHasChanged:
+            for child in self.children:
+                child.update_transform_from_parent()
         return super().itemChange(change, value)
 
     def set_parent_piece(self, parent, rel_x=0.0, rel_y=0.0):

--- a/tests/test_puppet_graphics.py
+++ b/tests/test_puppet_graphics.py
@@ -47,3 +47,19 @@ def test_hierarchy_and_pivot(app):
 
     # L'ordre d'affichage reste celui défini manuellement
     assert upper.zValue() == -1
+
+
+def test_puppet_translation(app):
+    window = MainWindow()
+
+    torso = window.graphics_items["manu:torse"]
+    elbow = window.graphics_items["manu:coude_droite"]
+
+    before = elbow.mapToScene(elbow.transformOriginPoint())
+
+    dx, dy = 50, 30
+    torso.setPos(torso.x() + dx, torso.y() + dy)
+
+    after = elbow.mapToScene(elbow.transformOriginPoint())
+    assert after.x() == pytest.approx(before.x() + dx)
+    assert after.y() == pytest.approx(before.y() + dy)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QMainWindow, QGraphicsView, QGraphicsScene, QVBoxLayout,
-    QWidget, QGraphicsPixmapItem
+    QWidget, QGraphicsPixmapItem, QGraphicsItem
 )
 from PySide6.QtGui import QPainter, QPixmap
 from PySide6.QtCore import Qt
@@ -97,6 +97,8 @@ class MainWindow(QMainWindow):
                 piece.set_parent_piece(parent_piece, rel_x, rel_y)
             else:
                 piece.setPos(offset_x, offset_y)
+                piece.setFlag(QGraphicsItem.ItemIsMovable, True)
+                piece.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
 
         # Ajout des items à la scène
         for piece in pieces.values():


### PR DESCRIPTION
## Summary
- propagate position updates to child pieces so the puppet stays coherent when moved
- mark the root puppet piece as movable and send geometry changes to support scene-wide translation
- test that moving the torso drags all limbs consistently

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894db33858c832bb5c303b380a2cec9