### PR TITLE
Restore scene objects on JSON import

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -47,6 +47,7 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
     *   **Centrage de la Vue**: Une option permet de **centrer la vue sur le pantin**.
     *   **Arrière-plan Personnalisable**: Possibilité de charger une **image d'arrière-plan** qui s'adapte automatiquement à la taille de la scène.
 *   **Sauvegarde et Chargement**: L'ensemble de la scène d'animation, y compris toutes les keyframes et les réglages de la timeline (FPS, plage de lecture), peut être sauvegardé dans un fichier `.json` et rechargé ultérieurement.
+    *   Les objets présents dans la scène sont également reconstruits lors du chargement du fichier.
 
 ## État actuel et prochaines étapes possibles
 

--- a/core/scene_model.py
+++ b/core/scene_model.py
@@ -150,6 +150,24 @@ class SceneModel:
         self.scene_height = settings.get("scene_height", 1080)
         self.background_path = settings.get("background_path", None)
 
+        # Recharge les objets de la scène
+        self.objects.clear()
+        objects_data = data.get("objects", {})
+        for name, obj_data in objects_data.items():
+            obj = SceneObject(
+                name=name,
+                obj_type=obj_data.get("obj_type"),
+                file_path=obj_data.get("file_path"),
+                x=obj_data.get("x", 0),
+                y=obj_data.get("y", 0),
+                rotation=obj_data.get("rotation", 0),
+                scale=obj_data.get("scale", 1.0),
+            )
+            attached_to = obj_data.get("attached_to")
+            if attached_to:
+                obj.attached_to = tuple(attached_to)
+            self.objects[name] = obj
+
         self.keyframes.clear()
 
         loaded_keyframes = data.get("keyframes", [])
@@ -160,7 +178,7 @@ class SceneModel:
                 new_kf.objects = kf_data.get("objects", {})
                 new_kf.puppets = kf_data.get("puppets", {})
                 self.keyframes[index] = new_kf
-        
+
         self.keyframes = dict(sorted(self.keyframes.items()))
 
 

--- a/tests/test_scene_model_io.py
+++ b/tests/test_scene_model_io.py
@@ -1,0 +1,21 @@
+import json
+from core.scene_model import SceneModel, SceneObject
+
+def test_scene_object_export_import(tmp_path):
+    scene = SceneModel()
+    obj = SceneObject("tree", "image", "tree.png", x=10, y=20, rotation=5, scale=1.5)
+    scene.add_object(obj)
+    scene.add_keyframe(0)
+    file_path = tmp_path / "scene.json"
+    scene.export_json(file_path)
+
+    scene2 = SceneModel()
+    scene2.import_json(file_path)
+
+    assert "tree" in scene2.objects
+    loaded = scene2.objects["tree"]
+    assert loaded.x == 10
+    assert loaded.y == 20
+    assert loaded.rotation == 5
+    assert loaded.scale == 1.5
+    assert loaded.file_path == "tree.png"


### PR DESCRIPTION
## Summary
- ensure SceneModel.import_json rebuilds SceneObject instances from saved data
- cover scene model import/export with a unit test
- document that scene objects are reloaded when importing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896882dbb80832b81304f6beb26b992