### PR TITLE
feat: add explicit scene object serialization

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -63,6 +63,7 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
 *   **Sauvegarde et Chargement**:
     *   L'ensemble de la scène (marionnettes, objets, keyframes, réglages) est sérialisé dans un fichier `.json`.
     *   Le chargement d'un fichier restaure l'intégralité de l'état de la scène.
+    *   La sérialisation des objets est désormais centralisée via `SceneObject.to_dict` / `SceneObject.from_dict` pour un export plus fiable.
 
 ## État actuel et prochaines étapes possibles
 

--- a/tests/test_scene_model_io.py
+++ b/tests/test_scene_model_io.py
@@ -1,6 +1,20 @@
 import json
 from core.scene_model import SceneModel, SceneObject
 
+def test_scene_object_roundtrip():
+    obj = SceneObject("rock", "image", "rock.png", x=1, y=2, rotation=3, scale=0.5)
+    obj.attach("p", "arm")
+    data = obj.to_dict()
+    cloned = SceneObject.from_dict(data)
+    assert cloned.name == "rock"
+    assert cloned.obj_type == "image"
+    assert cloned.file_path == "rock.png"
+    assert cloned.x == 1
+    assert cloned.y == 2
+    assert cloned.rotation == 3
+    assert cloned.scale == 0.5
+    assert cloned.attached_to == ("p", "arm")
+
 def test_scene_object_export_import(tmp_path):
     scene = SceneModel()
     obj = SceneObject("tree", "image", "tree.png", x=10, y=20, rotation=5, scale=1.5)


### PR DESCRIPTION
## Summary
- add `SceneObject.to_dict` and `SceneObject.from_dict` for robust serialization
- leverage new serialization helpers in keyframes, export and import
- document serialization change

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file: No such file or directory, ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6897aaab8680832b8ad73baaf777a294