### PR TITLE
Ensure core package and load local assets

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,18 @@
+"""Core domain models and helpers for BaBv2."""
+
+from .scene_model import SceneModel, SceneObject, Keyframe
+from .puppet_model import Puppet, PuppetMember
+from .puppet_piece import PuppetPiece
+from .svg_loader import SvgLoader, translate_path
+
+__all__ = [
+    "SceneModel",
+    "SceneObject",
+    "Keyframe",
+    "Puppet",
+    "PuppetMember",
+    "PuppetPiece",
+    "SvgLoader",
+    "translate_path",
+]
+

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -253,7 +253,9 @@ class MainWindow(QMainWindow):
         self.timeline_dock.visibilityChanged.connect(lambda _: self.ensure_fit())
         self.timeline_dock.topLevelChanged.connect(lambda _: self.ensure_fit())
         self.ensure_fit()
-        self.import_scene("demo.json")
+        # Load a minimal default scene using repo-relative assets so tests don't
+        # rely on developer specific absolute paths.
+        self._create_blank_scene()
         self.ensure_fit()
         self.scene.selectionChanged.connect(self._on_scene_selection_changed)
 
@@ -613,7 +615,9 @@ class MainWindow(QMainWindow):
         self.graphics_items.clear()
         self.scene_model.keyframes.clear()
         self.timeline_widget.clear_keyframes()
-        self.add_puppet("assets/test_genou.svg", "manu")
+        # Use the repository's sample puppet asset. The previous path pointed to
+        # a non-existent file which caused KeyError in tests.
+        self.add_puppet("assets/pantins/manululu.svg", "manu")
         self._update_timeline_ui_from_model()
         self.inspector_widget.refresh()
 


### PR DESCRIPTION
## Summary
- expose core modules as package for easier imports
- load a blank scene with repo assets instead of user-specific demo
- use existing puppet SVG in blank scene setup

## Testing
- `PYTHONPATH=. QT_QPA_PLATFORM=offscreen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897e9e46f24832b8db1db77456f2f20