### PR TITLE
Refactor scene I/O and inspector management

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -66,11 +66,14 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
     *   **Personnalisation de la scène**:
         *   Définition de la taille (largeur/hauteur) de la scène.
         *   Chargement d'une **image d'arrière-plan** qui s'adapte à la scène.
+    *   **Styles et constantes unifiés**:
+        *   Style des boutons factorisé dans `ui/styles.py` pour cohérence.
+        *   Chaîne MIME partagée (`LIB_MIME`) pour le glisser-déposer d'éléments.
 
 *   **Sauvegarde et Chargement**:
     *   L'ensemble de la scène (marionnettes, objets, keyframes, réglages) est sérialisé dans un fichier `.json`.
     *   Le chargement d'un fichier restaure l'intégralité de l'état de la scène.
-    *   Sérialisation des objets via `SceneObject.to_dict` / `SceneObject.from_dict` (incluant rotation/échelle/z et attachements) pour un export fiable.
+    *   Sérialisation centralisée via `SceneModel.to_dict` / `from_dict` (incluant objets et keyframes) pour un export fiable.
 
 ## État actuel et prochaines étapes possibles
 

--- a/tests/test_puppet_graphics.py
+++ b/tests/test_puppet_graphics.py
@@ -1,5 +1,4 @@
 import os
-
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 from PySide6.QtWidgets import QApplication, QGraphicsItem
@@ -24,9 +23,10 @@ def app():
 def test_hierarchy_and_pivot(app):
     window = MainWindow()
 
-    upper = window.graphics_items["manu:haut_bras_droite"]
-    elbow = window.graphics_items["manu:coude_droite"]
-    forearm = window.graphics_items["manu:avant_bras_droite"]
+    gis = window.object_manager.graphics_items
+    upper = gis["manu:haut_bras_droite"]
+    elbow = gis["manu:coude_droite"]
+    forearm = gis["manu:avant_bras_droite"]
 
     # Vérifie la hiérarchie logique sans impact sur l'affichage
     assert forearm.parent_piece is elbow
@@ -51,8 +51,9 @@ def test_hierarchy_and_pivot(app):
 
 def test_puppet_translation(app):
     window = MainWindow()
-    torso = window.graphics_items["manu:torse"]
-    hand = window.graphics_items["manu:main_droite"]
+    gis = window.object_manager.graphics_items
+    torso = gis["manu:torse"]
+    hand = gis["manu:main_droite"]
 
     # Le torse doit être déplaçable
     assert torso.flags() & QGraphicsItem.ItemIsMovable

--- a/ui/inspector_widget.py
+++ b/ui/inspector_widget.py
@@ -107,7 +107,7 @@ class InspectorWidget(QWidget):
             # Sélectionner l'objet dans la scène
             for it in self.main_window.scene.selectedItems():
                 it.setSelected(False)
-            gi = self.main_window.graphics_items.get(name)
+            gi = self.main_window.object_manager.graphics_items.get(name)
             if gi and gi.isVisible():
                 gi.setSelected(True)
             # Pré-sélectionner les combos selon l'état à la frame courante
@@ -125,7 +125,7 @@ class InspectorWidget(QWidget):
                 self.attach_puppet_combo.setCurrentIndex(0)
                 self._refresh_attach_member_combo()
         else:
-            scale = self.main_window.puppet_scales.get(name, 1.0)
+            scale = self.main_window.object_manager.puppet_scales.get(name, 1.0)
             rot = 0.0
             z = 0
             # Rien à afficher pour les pantins
@@ -147,16 +147,16 @@ class InspectorWidget(QWidget):
             obj = self.main_window.scene_model.objects.get(name)
             if obj:
                 obj.scale = value
-                item = self.main_window.graphics_items.get(name)
+                item = self.main_window.object_manager.graphics_items.get(name)
                 if item:
                     item.setScale(value)
         else:
-            old = self.main_window.puppet_scales.get(name, 1.0)
+            old = self.main_window.object_manager.puppet_scales.get(name, 1.0)
             if value <= 0:
                 return
             ratio = value / old if old else value
-            self.main_window.puppet_scales[name] = value
-            self.main_window.scale_puppet(name, ratio)
+            self.main_window.object_manager.puppet_scales[name] = value
+            self.main_window.object_manager.scale_puppet(name, ratio)
 
     def _on_delete_clicked(self):
         typ, name = self._current_info()
@@ -164,9 +164,9 @@ class InspectorWidget(QWidget):
             return
         if typ == "object":
             # Suppression temporelle: à partir de la frame courante
-            self.main_window.delete_object_from_current_frame(name)
+            self.main_window.object_manager.delete_object_from_current_frame(name)
         else:
-            self.main_window.delete_puppet(name)
+            self.main_window.object_manager.delete_puppet(name)
         self.refresh()
 
     def _on_duplicate_clicked(self):
@@ -174,9 +174,9 @@ class InspectorWidget(QWidget):
         if not name:
             return
         if typ == "object":
-            self.main_window.duplicate_object(name)
+            self.main_window.object_manager.duplicate_object(name)
         else:
-            self.main_window.duplicate_puppet(name)
+            self.main_window.object_manager.duplicate_puppet(name)
         self.refresh()
 
     def _on_rotation_changed(self, value: float):
@@ -184,7 +184,7 @@ class InspectorWidget(QWidget):
         if typ != "object" or not name:
             return
         obj = self.main_window.scene_model.objects.get(name)
-        item = self.main_window.graphics_items.get(name)
+        item = self.main_window.object_manager.graphics_items.get(name)
         if obj and item:
             obj.rotation = value
             try:
@@ -198,7 +198,7 @@ class InspectorWidget(QWidget):
         if typ != "object" or not name:
             return
         obj = self.main_window.scene_model.objects.get(name)
-        item = self.main_window.graphics_items.get(name)
+        item = self.main_window.object_manager.graphics_items.get(name)
         if obj and item:
             obj.z = int(value)
             item.setZValue(int(value))
@@ -229,14 +229,14 @@ class InspectorWidget(QWidget):
         puppet = self.attach_puppet_combo.currentText()
         member = self.attach_member_combo.currentText()
         if puppet and member:
-            self.main_window.attach_object_to_member(name, puppet, member)
+            self.main_window.object_manager.attach_object_to_member(name, puppet, member)
             self._on_item_changed(self.list_widget.currentItem(), None)
 
     def _on_detach_clicked(self):
         typ, name = self._current_info()
         if typ != "object" or not name:
             return
-        self.main_window.detach_object(name)
+        self.main_window.object_manager.detach_object(name)
         self._on_item_changed(self.list_widget.currentItem(), None)
 
     # --- Helpers ---

--- a/ui/object_manager.py
+++ b/ui/object_manager.py
@@ -100,6 +100,20 @@ class ObjectManager:
             self.puppet_scales[new_name] = scale
             self.scale_puppet(new_name, scale)
 
+    def capture_puppet_states(self):
+        states = {}
+        for name, puppet in self.scene_model.puppets.items():
+            puppet_state = {}
+            for member_name in puppet.members:
+                piece = self.graphics_items.get(f"{name}:{member_name}")
+                if piece:
+                    puppet_state[member_name] = {
+                        'rotation': piece.local_rotation,
+                        'pos': (piece.x(), piece.y()),
+                    }
+            states[name] = puppet_state
+        return states
+
     def delete_object(self, name):
         if (item := self.graphics_items.pop(name, None)): self.scene.removeItem(item)
         self.scene_model.remove_object(name)

--- a/ui/styles.py
+++ b/ui/styles.py
@@ -1,0 +1,16 @@
+BUTTON_STYLE = """
+    QToolButton {
+        background-color: transparent;
+        border: none;
+        padding: 2px;
+        color: #E0E0E0;
+    }
+    QToolButton:checked {
+        background-color: rgba(255, 255, 255, 25);
+        border-radius: 4px;
+    }
+    QToolButton:hover {
+        background-color: rgba(255, 255, 255, 40);
+        border-radius: 4px;
+    }
+"""

--- a/ui/zoomable_view.py
+++ b/ui/zoomable_view.py
@@ -11,9 +11,11 @@ from PySide6.QtCore import Qt, Signal, QPointF, QSize
 
 from ui.draggable_widget import DraggableOverlay
 from ui.icons import (
-    icon_plus, icon_minus, icon_fit, icon_rotate, 
+    icon_plus, icon_minus, icon_fit, icon_rotate,
     icon_chevron_left, icon_chevron_right
 )
+from ui.styles import BUTTON_STYLE
+from ui.library_widget import LIB_MIME
 
 
 class ZoomableView(QGraphicsView):
@@ -40,31 +42,15 @@ class ZoomableView(QGraphicsView):
         icon_size = 32
         button_size = 36
 
-        button_style = f"""
-            QToolButton {{
-                background-color: transparent;
-                border: none;
-                padding: 2px;
-            }}
-            QToolButton:checked {{
-                background-color: rgba(255, 255, 255, 25);
-                border-radius: 4px;
-            }}
-            QToolButton:hover {{
-                background-color: rgba(255, 255, 255, 40);
-                border-radius: 4px;
-            }}
-        """
-
         def make_btn(icon: QIcon | None, tooltip, cb=None, checkable=False):
             btn = QToolButton(self._overlay)
-            if icon: 
+            if icon:
                 btn.setIcon(icon)
                 btn.setIconSize(QSize(icon_size, icon_size))
             btn.setToolTip(tooltip)
             if cb: btn.clicked.connect(cb)
             btn.setCheckable(checkable)
-            btn.setStyleSheet(button_style)
+            btn.setStyleSheet(BUTTON_STYLE)
             btn.setFixedSize(button_size, button_size)
             btn.setAutoRaise(True)
             return btn
@@ -142,21 +128,21 @@ class ZoomableView(QGraphicsView):
         super().mouseReleaseEvent(event)
 
     def dragEnterEvent(self, event):
-        if event.mimeData().hasFormat('application/x-bab-item'):
+        if event.mimeData().hasFormat(LIB_MIME):
             event.acceptProposedAction()
         else:
             super().dragEnterEvent(event)
 
     def dragMoveEvent(self, event):
-        if event.mimeData().hasFormat('application/x-bab-item'):
+        if event.mimeData().hasFormat(LIB_MIME):
             event.acceptProposedAction()
         else:
             super().dragMoveEvent(event)
 
     def dropEvent(self, event):
-        if event.mimeData().hasFormat('application/x-bab-item'):
+        if event.mimeData().hasFormat(LIB_MIME):
             try:
-                data = bytes(event.mimeData().data('application/x-bab-item')).decode('utf-8')
+                data = bytes(event.mimeData().data(LIB_MIME)).decode('utf-8')
                 payload = json.loads(data)
                 self.item_dropped.emit(payload, event.position())
             except Exception as e:


### PR DESCRIPTION
## Summary
- Centralize scene serialization with `SceneModel.to_dict`/`from_dict` and default to 1920×1080
- Route inspector operations through `ObjectManager` and expose puppet state capture for keyframes
- Share button styles and MIME type constants across UI components

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898a6ee5a84832b8fb63b1ac28b332c