### PR TITLE
Ensure scene fits view and overlay is collapsible

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -59,13 +59,14 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
 *   **Interface Utilisateur et Ergonomie (UI/UX) Améliorées**:
     *   **Vue de la scène professionnelle**:
         *   **Barre d'outils flottante (Overlay)** directement sur la vue pour un accès rapide au zoom, centrage, et affichage/masquage des poignées de rotation.
-        *   **Barre d'outils principale** pour les actions globales (gestion des panneaux, zoom).
+        *   **Barre d'outils principale** pour les actions globales (gestion des panneaux, zoom) désormais rétractable comme l'overlay de la vue.
         *   Panoramique dans la vue avec le clic molette.
     *   **Panneaux modulables (Docks)**: La Timeline et l'Inspecteur peuvent être affichés, masqués ou déplacés indépendamment (`F3`, `F4`).
     *   **Poignées de rotation basculables** pour désencombrer la vue.
     *   **Personnalisation de la scène**:
         *   Définition de la taille (largeur/hauteur) de la scène.
         *   Chargement d'une **image d'arrière-plan** qui s'adapte à la scène.
+        *   La taille de la scène s'ajuste automatiquement à l'image de fond et la vue se met immédiatement à l'échelle disponible au démarrage.
     *   **Styles et constantes unifiés**:
         *   Style des boutons factorisé dans `ui/styles.py` pour cohérence.
         *   Chaîne MIME partagée (`LIB_MIME`) pour le glisser-déposer d'éléments.

--- a/ui/object_manager.py
+++ b/ui/object_manager.py
@@ -249,7 +249,7 @@ class ObjectManager:
 
         if kind == 'background':
             self.scene_model.background_path = path
-            self.win._update_background()
+            self.win._update_background(adjust_scene=True)
         elif kind == 'object':
             self._create_object_from_file(path, scene_pos)
         elif kind == 'puppet':


### PR DESCRIPTION
## Summary
- Build and collapse the main toolbar overlay directly in `ZoomableView`
- Resize the scene to match background images and fit the view at startup
- Document overlay retraction and automatic scene sizing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898b8735544832ba64c5c0d26c99dd9