### PR TITLE
Expand test coverage and fix SVG path translation

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -75,6 +75,10 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
     *   Le chargement d'un fichier restaure l'intégralité de l'état de la scène.
     *   Sérialisation centralisée via `SceneModel.to_dict` / `from_dict` (incluant objets et keyframes) pour un export fiable.
 
+*   **Qualité et Tests**:
+    *   Corrections dans `SvgLoader.translate_path` pour préserver la structure des chemins SVG.
+    *   Ajout de tests unitaires couvrant les attachements et keyframes du `SceneModel`, les utilitaires de `SvgLoader` et les pivots du `Puppet`.
+
 ## État actuel et prochaines étapes possibles
 
 L'application a évolué d'un simple outil d'animation de marionnette à un **logiciel de composition de scène 2D fonctionnel et robuste**. L'interface a été professionnalisée et la gestion de plusieurs objets est désormais possible.

--- a/core/svg_loader.py
+++ b/core/svg_loader.py
@@ -121,7 +121,8 @@ def translate_path(d, dx, dy):
     Décale toutes les coordonnées d'un path SVG.
     """
     def repl(match):
-        nums = match.group(0).strip().split()
+        original = match.group(0)
+        nums = original.strip().split()
         new_nums = []
         for i, n in enumerate(nums):
             try:
@@ -133,6 +134,7 @@ def translate_path(d, dx, dy):
                 new_nums.append(str(num))
             except ValueError:
                 new_nums.append(n)
-        return " ".join(new_nums)
+        trailing = original[len(original.rstrip()):]
+        return " ".join(new_nums) + trailing
 
     return _COORD_PATTERN.sub(repl, d)

--- a/tests/test_scene_model_features.py
+++ b/tests/test_scene_model_features.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.scene_model import SceneModel, SceneObject
+
+def test_attach_detach_object():
+    scene = SceneModel()
+    obj = SceneObject("rock", "image", "rock.png")
+    scene.add_object(obj)
+
+    scene.attach_object("rock", "puppet", "arm")
+    assert scene.objects["rock"].attached_to == ("puppet", "arm")
+
+    scene.detach_object("rock")
+    assert scene.objects["rock"].attached_to is None
+
+def test_add_keyframe_captures_state_and_sorts():
+    scene = SceneModel()
+    obj = SceneObject("box", "image", "box.png", x=0, y=0)
+    scene.add_object(obj)
+
+    scene.add_keyframe(5)
+    obj.x = 10
+    scene.add_keyframe(2)
+
+    assert list(scene.keyframes.keys()) == [2,5]
+    assert scene.keyframes[5].objects["box"]["x"] == 0
+    assert scene.keyframes[2].objects["box"]["x"] == 10

--- a/tests/test_svg_loader_and_puppet.py
+++ b/tests/test_svg_loader_and_puppet.py
@@ -1,0 +1,64 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtWidgets import QApplication
+from core.svg_loader import SvgLoader, translate_path
+from core.puppet_model import compute_child_map, Puppet, PuppetMember
+
+import tempfile
+
+app = QApplication.instance() or QApplication([])
+
+def create_simple_svg(tmpdir: Path):
+    svg_content = """
+    <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+      <g id='g1'>
+        <rect x='10' y='20' width='30' height='40' />
+      </g>
+      <g id='g2'>
+        <circle cx='50' cy='50' r='10' />
+      </g>
+    </svg>
+    """
+    file_path = tmpdir / "test.svg"
+    file_path.write_text(svg_content)
+    return file_path
+
+def test_svg_loader_basic_functions(tmp_path):
+    svg_file = create_simple_svg(tmp_path)
+    loader = SvgLoader(str(svg_file))
+
+    groups = set(loader.get_groups())
+    assert {"g1", "g2"} <= groups
+
+    bbox = loader.get_group_bounding_box("g1")
+    assert bbox == (10.0, 20.0, 40.0, 60.0)
+
+    pivot = loader.get_pivot("g1")
+    assert pivot == (25.0, 40.0)
+
+def test_translate_path_preserves_whitespace():
+    d = "M 10 20 L 30 40"
+    translated = translate_path(d, 5, 10)
+    assert translated == "M 5.0 10.0 L 25.0 30.0"
+
+def test_compute_child_map_and_puppet_pivots():
+    parent_map = {"root": None, "child1": "root", "child2": "root"}
+    child_map = compute_child_map(parent_map)
+    assert child_map == {"root": ["child1", "child2"]}
+
+    puppet = Puppet()
+    parent = PuppetMember("root", pivot=(0,0))
+    child1 = PuppetMember("child1", pivot=(10,5))
+    child2 = PuppetMember("child2", pivot=(20,0))
+    puppet.members = {"root": parent, "child1": child1, "child2": child2}
+    puppet.child_map = child_map
+
+    assert puppet.get_first_child_pivot("root") == (10,5)
+    assert puppet.get_handle_target_pivot("root") == (10,5)
+    assert puppet.get_first_child_pivot("child1") == (None, None)


### PR DESCRIPTION
## Summary
- Fix `translate_path` in `SvgLoader` to retain whitespace when adjusting path coordinates
- Add tests for `SceneModel` attachment/keyframe features and for SVG/Puppet utilities
- Document improved test coverage and SVG path fix in state of the art

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c055f7d8832b9562b43029ae7d56