### PR TITLE
Improve test coverage for models

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -75,6 +75,10 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
     *   Le chargement d'un fichier restaure l'intégralité de l'état de la scène.
     *   Sérialisation centralisée via `SceneModel.to_dict` / `from_dict` (incluant objets et keyframes) pour un export fiable.
 
+*   **Tests unitaires renforcés**:
+    *   Couverture accrue des opérations du modèle de scène (attachements, gestion des keyframes).
+    *   Validation des helpers du modèle de marionnette comme `compute_child_map`.
+
 ## État actuel et prochaines étapes possibles
 
 L'application a évolué d'un simple outil d'animation de marionnette à un **logiciel de composition de scène 2D fonctionnel et robuste**. L'interface a été professionnalisée et la gestion de plusieurs objets est désormais possible.

--- a/core/scene_model.py
+++ b/core/scene_model.py
@@ -1,4 +1,5 @@
 from core.puppet_model import Puppet
+import copy
 
 class SceneObject:
     """
@@ -116,7 +117,7 @@ class SceneModel:
         for name, obj in self.objects.items():
             kf.objects[name] = obj.to_dict()
 
-        kf.puppets = puppet_states or {}
+        kf.puppets = copy.deepcopy(puppet_states) if puppet_states else {}
 
         self.keyframes = dict(sorted(self.keyframes.items()))
         return kf

--- a/tests/test_puppet_model.py
+++ b/tests/test_puppet_model.py
@@ -1,0 +1,19 @@
+from core.puppet_model import compute_child_map, Puppet, PuppetMember
+
+
+def test_compute_child_map_basic():
+    parent_map = {"b": "a", "c": "a", "d": "b"}
+    assert compute_child_map(parent_map) == {"a": ["b", "c"], "b": ["d"]}
+
+
+def test_get_first_child_pivot_and_handle_target():
+    puppet = Puppet()
+    root = PuppetMember("root")
+    child = PuppetMember("child", pivot=(1, 2))
+    root.add_child(child)
+    puppet.members = {"root": root, "child": child}
+    puppet.child_map = {"root": ["child"]}
+
+    assert puppet.get_first_child_pivot("root") == (1, 2)
+    assert puppet.get_first_child_pivot("child") == (None, None)
+    assert puppet.get_handle_target_pivot("root") == (1, 2)

--- a/tests/test_scene_model_io.py
+++ b/tests/test_scene_model_io.py
@@ -1,6 +1,40 @@
 import json
 from core.scene_model import SceneModel, SceneObject
 
+
+def test_attach_detach_object():
+    scene = SceneModel()
+    obj = SceneObject("box", "image", "box.png")
+    scene.add_object(obj)
+
+    scene.attach_object("box", "p", "hand")
+    assert scene.objects["box"].attached_to == ("p", "hand")
+
+    scene.detach_object("box")
+    assert scene.objects["box"].attached_to is None
+
+
+def test_add_keyframe_snapshot_and_order():
+    scene = SceneModel()
+    obj = SceneObject("ball", "image", "ball.png", x=1)
+    scene.add_object(obj)
+
+    scene.add_keyframe(10)
+    obj.x = 5
+    scene.add_keyframe(0)
+
+    assert [kf.index for kf in scene.keyframes.values()] == [0, 10]
+    assert scene.keyframes[10].objects["ball"]["x"] == 1
+    assert scene.keyframes[0].objects["ball"]["x"] == 5
+
+
+def test_puppet_states_are_copied():
+    scene = SceneModel()
+    state = {"p": {"member": {"rot": 0}}}
+    kf = scene.add_keyframe(0, puppet_states=state)
+    state["p"]["member"]["rot"] = 90
+    assert kf.puppets["p"]["member"]["rot"] == 0
+
 def test_scene_object_roundtrip():
     obj = SceneObject("rock", "image", "rock.png", x=1, y=2, rotation=3, scale=0.5)
     obj.attach("p", "arm")


### PR DESCRIPTION
## Summary
- Fix SceneModel keyframe state copying
- Add SceneModel unit tests for attachments, keyframe ordering and puppet state isolation
- Add Puppet model helper tests and document new coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c055f7d8832b9562b43029ae7d56