### PR TITLE
docs: ajouter revues de code détaillées

### DIFF
--- a/code_reviews/actions_prioritaires.md
+++ b/code_reviews/actions_prioritaires.md
@@ -1,0 +1,29 @@
+# Synthèse des actions prioritaires
+
+1. **Refactorisation structurelle**
+   - Découper `ui/main_window.py` (718 lignes) et `ui/object_manager.py` (>400 lignes) en modules plus petits pour améliorer la maintenabilité.
+   - Séparer la logique métier de l'UI lorsque c'est possible.
+
+2. **Amélioration de la documentation**
+   - Ajouter des docstrings et commentaires aux classes et méthodes majeures (notamment dans `core` et `ui/timeline_widget.py`).
+
+3. **Gestion des erreurs et logging**
+   - Remplacer les `print` par le module `logging` et éviter les `except Exception: pass`.
+   - Spécifier les exceptions attrapées et fournir des messages de log utiles.
+
+4. **Corrections techniques immédiates**
+   - Corriger l'import manquant de `os` dans `tests/test_puppet_graphics.py` et de `QWidget` dans `ui/draggable_widget.py`.
+   - Supprimer le code mort dans `core/scene_model.py` (`self.from_dict(data)` après `return`).
+   - Épingler les versions dans `requirements.txt` pour garantir la reproductibilité.
+
+5. **Tests et couverture**
+   - Introduire des tests unitaires pour les composants clés (`ui/timeline_widget.py`, `core/svg_loader.py`, `ui/zoomable_view.py`, etc.).
+   - Nettoyer les ressources (fenêtres, QApplications) dans les tests existants pour éviter les fuites.
+
+6. **Qualité du code**
+   - Uniformiser le style PEP8 (éliminer les instructions multiples par ligne, camelCase…).
+   - Clarifier ou factoriser les méthodes longues (`_build_overlay`, `create_blank_scene`, etc.).
+
+7. **Amélioration UX**
+   - Gérer les exceptions lors du chargement d'icônes ou de fichiers SVG pour informer l'utilisateur.
+   - Documenter et éventuellement paramétrer les chemins d'accès aux ressources (`ui/library_widget.py`).

--- a/code_reviews/core___init___review.md
+++ b/code_reviews/core___init___review.md
@@ -1,0 +1,10 @@
+# Revue de code : core/__init__.py
+
+## Observations Générales
+- Fournit un point d'entrée clair pour les modèles et helpers du domaine.
+- La docstring résume succinctement le module.
+- L'utilisation de `__all__` facilite l'import sélectif.
+
+## Recommandations
+1. Vérifier que l'import de tous les éléments exposés est réellement nécessaire pour éviter les dépendances circulaires.
+2. Envisager d'ajouter des commentaires ou docstrings supplémentaires pour expliquer les principaux objets exportés.

--- a/code_reviews/core_puppet_model_review.md
+++ b/code_reviews/core_puppet_model_review.md
@@ -1,0 +1,23 @@
+# Revue de code : core/puppet_model.py
+
+## Observations Générales
+- Définit la structure hiérarchique d'un pantin via les classes `Puppet` et `PuppetMember`.
+- Utilisation extensive de dictionnaires pour mapper relations, pivots et z-order.
+- Présence de fonctions utilitaires (`compute_child_map`, `validate_svg_structure`).
+
+## Points Positifs
+- Typage statique présent sur la majorité des fonctions et attributs.
+- Structure claire pour construire l'arbre des membres à partir d'un SVG.
+
+## Problèmes Identifiés
+1. Module très long sans séparation claire en sous-modules ; difficulté de maintenance.
+2. Beaucoup de `print` pour le debug (`print_hierarchy`, `validate_svg_structure`, `main`).
+3. Docstrings absentes pour plusieurs fonctions/méthodes importantes (`compute_child_map`, `build_from_svg`).
+4. Valeurs magiques utilisées dans les mappings (`PARENT_MAP`, `PIVOT_MAP`, `Z_ORDER`) sans justification ni lien avec la ressource SVG.
+5. Manque de tests unitaires couvrant la construction des puppets et la validation du SVG.
+
+## Recommandations
+- Remplacer les `print` par un système de `logging` configurable.
+- Ajouter des docstrings détaillées et éventuellement des commentaires décrivant l'origine des constantes.
+- Envisager de découper le module en plusieurs fichiers (par ex. `constants`, `builder`, `validator`).
+- Créer des tests pour `compute_child_map` et `build_from_svg` afin d'assurer le comportement attendu.

--- a/code_reviews/core_puppet_piece_review.md
+++ b/code_reviews/core_puppet_piece_review.md
@@ -1,0 +1,22 @@
+# Revue de code : core/puppet_piece.py
+
+## Observations Générales
+- Implémentation graphique d'un membre de pantin avec gestion des poignées de rotation et de pivot.
+- Nombreuses dépendances PySide6 pour la manipulation de la scène graphique.
+- Utilisation de constantes pour z-order et mots-clés.
+
+## Points Positifs
+- Typage explicite et annotations sur les méthodes principales.
+- Gestion cohérente des relations parent/enfant et de la propagation des transformations.
+
+## Problèmes Identifiés
+1. Absence de docstrings pour la plupart des classes et méthodes, ce qui réduit la compréhension du comportement.
+2. Import de `Optional`, `Tuple`, `List`, `Any` après d'autres imports ; pourrait être regroupé pour plus de lisibilité.
+3. Certaines conditions (`if not any(keyword in name for keyword in PIVOT_KEYWORDS)`) pourraient être clarifiées ou extraites en fonction.
+4. Pas de tests unitaires couvrant les transformations ou la manipulation des poignées.
+5. Utilisation de `print` nulle ici, mais le module pourrait bénéficier d'un logging pour les débogages futurs.
+
+## Recommandations
+- Ajouter des docstrings et commentaires pour expliquer la logique des transformations et l'utilisation des handles.
+- Réorganiser les imports et envisager de séparer les constantes dans un module dédié.
+- Introduire des tests pour `update_transform_from_parent` et `rotate_piece` afin de garantir la stabilité des transformations.

--- a/code_reviews/core_scene_model_review.md
+++ b/code_reviews/core_scene_model_review.md
@@ -1,0 +1,21 @@
+# Revue de code : core/scene_model.py
+
+## Observations Générales
+- Définit les classes `SceneObject`, `Keyframe` et `SceneModel` avec une structure claire.
+- Sérialisation JSON prévue via `to_dict`/`from_dict` et `export_json`/`import_json`.
+- Présence de commentaires utiles mais peu de docstrings détaillées sur les méthodes.
+
+## Points Positifs
+- Utilisation de `typing` pour améliorer la lisibilité et la robustesse.
+- Tri des keyframes après insertion assurant l'ordre chronologique.
+
+## Problèmes Identifiés
+1. Import `logging` utilisé uniquement dans `import_json` ; vérifier qu'une configuration de logging existe ailleurs.
+2. Méthode `import_json` contient une ligne `self.from_dict(data)` après le `return False`, code mort à supprimer.
+3. Manque de validations sur les valeurs (ex. type de `index`, existence des clés) lors de la désérialisation.
+4. Peu ou pas de tests unitaires associés aux objets `SceneObject`.
+
+## Recommandations
+- Ajouter des docstrings aux méthodes principales pour clarifier leur usage.
+- Introduire des exceptions spécifiques ou des retours d'erreur détaillés pour l'import/export.
+- Élargir la couverture de tests pour la sérialisation des `SceneObject` et la gestion des keyframes.

--- a/code_reviews/core_svg_loader_review.md
+++ b/code_reviews/core_svg_loader_review.md
@@ -1,0 +1,21 @@
+# Revue de code : core/svg_loader.py
+
+## Observations Générales
+- Classe utilitaire orientée sur la manipulation d'éléments SVG avec PySide6.
+- Typage détaillé et utilisation d'`ElementTree` appropriée.
+- Certaines méthodes possèdent des docstrings claires.
+
+## Points Positifs
+- Validation des éléments et gestion des erreurs via exceptions ou `None`.
+- Utilisation de regex pour la traduction des paths SVG.
+
+## Problèmes Identifiés
+1. Mélange d'utilisation de `print` et de `logging` pour le retour utilisateur (`extract_group`).
+2. Docstring de `get_pivot` peu informative ; manque de description sur les paramètres et retours.
+3. Absence de tests unitaires pour vérifier les opérations sur les groupes et la translation des paths.
+4. Certaines méthodes pourraient bénéficier d'une gestion d'exceptions plus fine (ex. parsing XML).
+
+## Recommandations
+- Uniformiser la sortie console en privilégiant `logging`.
+- Enrichir les docstrings et ajouter des exemples d'utilisation.
+- Ajouter des tests couvrant `extract_group` et `translate_path` pour garantir leur fiabilité.

--- a/code_reviews/macronotron_review.md
+++ b/code_reviews/macronotron_review.md
@@ -1,0 +1,11 @@
+# Revue de code : macronotron.py
+
+## Observations Générales
+- Fichier principal très concis, clair et bien structuré.
+- Import `logging` non utilisé.
+- Aucun commentaire ou docstring expliquant le rôle du script.
+
+## Recommandations
+1. Supprimer l'import `logging` si aucune journalisation n'est prévue.
+2. Ajouter une docstring en tête de fichier décrivant l'objectif du module.
+3. Prévoir un mécanisme de gestion des exceptions au lancement de l'application pour une meilleure robustesse.

--- a/code_reviews/requirements.txt_review.md
+++ b/code_reviews/requirements.txt_review.md
@@ -1,0 +1,9 @@
+# Revue de code : requirements.txt
+
+## Observations Générales
+- Liste de dépendances minimale.
+- Aucune version précisée pour les paquets.
+
+## Recommandations
+1. Épingler les versions (`PySide6==<version>`, `pytest==<version>`) pour garantir la reproductibilité.
+2. Ajouter éventuellement des commentaires sur le rôle de chaque dépendance si la liste s'allonge.

--- a/code_reviews/tests_test_object_keyframe_states_review.md
+++ b/code_reviews/tests_test_object_keyframe_states_review.md
@@ -1,0 +1,19 @@
+# Revue de code : tests/test_object_keyframe_states.py
+
+## Observations Générales
+- Test fonctionnel vérifiant que l'état des objets est spécifique à chaque keyframe.
+- Utilisation de PySide6 dans un contexte de test avec fixture `QApplication`.
+
+## Points Positifs
+- Scénario de test complet couvrant l'attachement/détachement et la restitution de position.
+- Vérifications précises via `pytest.approx` pour les valeurs flottantes.
+
+## Problèmes Identifiés
+1. Absence de nettoyage de la fenêtre `MainWindow` après le test, pouvant provoquer des fuites de ressources.
+2. Importation et manipulation directe du chemin système (`sys.path.append`), ce qui peut être fragile.
+3. Aucun commentaire expliquant le but global du test ; la lisibilité peut être améliorée.
+
+## Recommandations
+- Fermer/cleanup la fenêtre `MainWindow` à la fin du test.
+- Utiliser des fixtures ou helpers pour gérer l'ajout de chemins plutôt que `sys.path.append`.
+- Ajouter des commentaires ou docstrings pour clarifier les étapes du scénario de test.

--- a/code_reviews/tests_test_puppet_graphics_review.md
+++ b/code_reviews/tests_test_puppet_graphics_review.md
@@ -1,0 +1,21 @@
+# Revue de code : tests/test_puppet_graphics.py
+
+## Observations Générales
+- Tests de rendu graphique pour vérifier la hiérarchie et les transformations du pantin.
+- Utilise `QT_QPA_PLATFORM=offscreen` pour exécuter Qt sans affichage.
+
+## Points Positifs
+- Vérifie correctement les relations parent/enfant et la propagation des rotations/translations.
+- Utilisation pertinente de `pytest.approx` pour comparer des coordonnées flottantes.
+
+## Problèmes Identifiés
+1. Manque d'importation du module `os` alors qu'il est utilisé pour définir `QT_QPA_PLATFORM`.
+2. La fenêtre `MainWindow` n'est pas nettoyée après chaque test, ce qui peut entraîner des fuites de ressources.
+3. `sys.path.append` est utilisé directement ; cette approche peut être fragile.
+4. Aucun commentaire expliquant la logique globale des tests.
+
+## Recommandations
+- Ajouter `import os` en tête du fichier.
+- Fermer la fenêtre `MainWindow` à la fin des tests ou utiliser des fixtures dédiées.
+- Remplacer `sys.path.append` par un mécanisme plus robuste (ex. package installé ou fixture).
+- Ajouter des commentaires/docstrings pour clarifier l'intention des tests.

--- a/code_reviews/tests_test_scene_model_io_review.md
+++ b/code_reviews/tests_test_scene_model_io_review.md
@@ -1,0 +1,19 @@
+# Revue de code : tests/test_scene_model_io.py
+
+## Observations Générales
+- Tests unitaires simples couvrant la sérialisation et l'export/import du modèle de scène.
+- Bon usage de `tmp_path` pour les opérations fichier.
+
+## Points Positifs
+- Vérifie le round-trip `SceneObject.to_dict` -> `from_dict`.
+- Teste la persistance via `export_json` et `import_json`.
+
+## Problèmes Identifiés
+1. Aucun test pour les erreurs possibles (fichier corrompu, attribut manquant, etc.).
+2. Absence de docstrings pour expliquer la finalité de chaque test.
+3. Les assertions pourraient être regroupées ou factorisées pour réduire la duplication.
+
+## Recommandations
+- Ajouter des cas de tests négatifs pour vérifier la robustesse de `import_json`.
+- Introduire des commentaires/docstrings pour clarifier l'intention de chaque test.
+- Utiliser des helpers ou fixtures pour créer des objets `SceneObject` réutilisables.

--- a/code_reviews/ui_draggable_widget_review.md
+++ b/code_reviews/ui_draggable_widget_review.md
@@ -1,0 +1,21 @@
+# Revue de code : ui/draggable_widget.py
+
+## Observations Générales
+- Contient des classes utilitaires pour créer des overlays déplaçables et redimensionnables.
+- Trois classes principales : `DraggableOverlay`, `PanelOverlay`, `DraggableHeader`.
+
+## Points Positifs
+- Gestion du drag par clic droit pour déplacer les overlays, et clic gauche pour redimensionner (`PanelOverlay`).
+- Effet d'ombre appliqué pour améliorer le rendu visuel.
+
+## Problèmes Identifiés
+1. `QWidget` est utilisé mais non importé (`from PySide6.QtWidgets import QWidget, ...`).
+2. Absence totale de docstrings pour `DraggableOverlay` et `PanelOverlay`.
+3. Plusieurs blocs `except Exception: pass` qui masquent les erreurs potentielles.
+4. Les méthodes `_get_edge`, `mousePressEvent`, `mouseMoveEvent` et `mouseReleaseEvent` sont volumineuses et gagneraient à être commentées.
+
+## Recommandations
+- Ajouter l'import manquant de `QWidget`.
+- Documenter les classes et méthodes pour clarifier leur comportement.
+- Remplacer les `except Exception` génériques par des exceptions plus précises accompagnées d'un logging.
+- Simplifier ou découper les méthodes longues pour améliorer la lisibilité.

--- a/code_reviews/ui_icons_review.md
+++ b/code_reviews/ui_icons_review.md
@@ -1,0 +1,21 @@
+# Revue de code : ui/icons.py
+
+## Observations Générales
+- Module centralisant la génération d'icônes SVG recolorisées selon les états (normal, hover, actif).
+- Utilisation d'un cache pour éviter de recharger les icônes.
+
+## Points Positifs
+- Fonction `_render_svg` bien isolée pour le rendu.
+- `get_icon` fournit une API unique, les anciennes fonctions restant pour compatibilité.
+
+## Problèmes Identifiés
+1. `ICON_CACHE[name] = QIcon(); return QIcon()` en cas de fichier manquant : l'icône mise en cache n'est pas retournée.
+2. Pas de gestion d'erreurs lors de l'ouverture des fichiers SVG (ex. fichier corrompu).
+3. Absence de docstring pour `get_icon` et les fonctions de compatibilité.
+4. `icon_reset_ui` renvoie l'icône `rotate` (semble être un raccourci temporaire?).
+
+## Recommandations
+- Retourner l'icône mise en cache même si vide (`return ICON_CACHE[name]`).
+- Ajouter des try/except avec logging pour la lecture des fichiers SVG.
+- Documenter `get_icon` et envisager de déprécier les fonctions spécifiques.
+- Vérifier la correspondance entre les noms d'icônes et leur usage (`icon_reset_ui`).

--- a/code_reviews/ui_inspector_widget_review.md
+++ b/code_reviews/ui_inspector_widget_review.md
@@ -1,0 +1,22 @@
+# Revue de code : ui/inspector_widget.py
+
+## Observations Générales
+- Widget d'inspection permettant de gérer objets et pantins (échelle, rotation, attache...).
+- Construction et connexion des widgets regroupées dans `__init__`.
+
+## Points Positifs
+- Interface utilisateur complète avec signaux/connecteurs appropriés.
+- Méthodes helpers pour resynchroniser l'état selon la frame courante.
+
+## Problèmes Identifiés
+1. Peu de docstrings : seules les méthodes publiques `refresh` et `_attached_state_for_frame` sont documentées.
+2. `__init__` est long et mélange création d'UI, layout et connexions ; difficile à maintenir.
+3. Certains blocs `try/except` sans log (`except Exception: pass`) masquent des erreurs potentielles.
+4. Utilisation de noms de variables peu explicites (`si` pour `sorted indices`).
+5. Aucune gestion de nettoyage/fermeture des ressources graphiques.
+
+## Recommandations
+- Factoriser la construction de l'UI en méthodes privées distinctes pour clarifier `__init__`.
+- Ajouter des docstrings aux méthodes principales et aux callbacks pour améliorer la compréhension.
+- Remplacer les `except Exception` génériques par des exceptions ciblées accompagnées de logs.
+- Renommer les variables ambiguës (`si` -> `sorted_indices` par exemple).

--- a/code_reviews/ui_library_widget_review.md
+++ b/code_reviews/ui_library_widget_review.md
@@ -1,0 +1,21 @@
+# Revue de code : ui/library_widget.py
+
+## Observations Générales
+- Fournit un widget de bibliothèque avec drag-and-drop pour arrière-plans, objets et pantins.
+- Séparation claire entre la grille interne `_DraggableGrid` et le widget principal `LibraryWidget`.
+
+## Points Positifs
+- Utilisation de `QTabWidget` pour organiser les catégories d'actifs.
+- Signaux `addRequested` permettant une intégration facile avec le reste de l'application.
+
+## Problèmes Identifiés
+1. Pas de docstrings pour les classes ni pour `reload`, limitant la compréhension.
+2. Gestion d'exceptions silencieuse lors du chargement des icônes (`except Exception: pass`).
+3. Les chemins d'accès aux dossiers d'actifs sont codés en dur ; manque de paramétrage.
+4. `mouseDoubleClickEvent` contient un `return` après `event.accept()` sur la même ligne, réduisant la lisibilité.
+
+## Recommandations
+- Ajouter des docstrings et commentaires pour décrire le fonctionnement des classes.
+- Logguer les exceptions lors du chargement d'icônes afin de faciliter le diagnostic.
+- Permettre la configuration des chemins d'actifs via des paramètres ou un fichier de configuration.
+- Simplifier la structure de `mouseDoubleClickEvent` pour améliorer la lisibilité.

--- a/code_reviews/ui_main_window_review.md
+++ b/code_reviews/ui_main_window_review.md
@@ -1,0 +1,23 @@
+# Revue de code : ui/main_window.py
+
+## Observations Générales
+- Fichier central de l'application (718 lignes) gérant la fenêtre principale, les overlays, la timeline et l'orchestration des actions.
+- Combine logique d'interface, gestion de scène et fonctionnalités avancées (onion skin, sauvegarde, etc.).
+
+## Points Positifs
+- Utilisation cohérente de classes spécialisées (`ObjectManager`, `PlaybackHandler`, `TimelineWidget`).
+- Nombreux paramètres configurables (onion skin, overlays, raccourcis).
+
+## Problèmes Identifiés
+1. Taille du module très importante rendant la maintenance difficile.
+2. Peu de docstrings ou commentaires explicatifs pour les méthodes privées/publics.
+3. Multiples blocs `try/except Exception: pass` qui masquent les erreurs.
+4. Mélange de responsabilités : gestion de l'UI, de la logique métier et du stockage des paramètres dans un même fichier.
+5. Utilisation de variables/attributs instanciés directement dans `__init__` sans encapsulation.
+6. Certaines méthodes (ex. gestion de l'onion skin) sont très longues et pourraient être extraites.
+
+## Recommandations
+- Refactoriser en plusieurs modules/classes pour séparer les responsabilités (ex. gestion des overlays, onion skin, persistance).
+- Ajouter des docstrings et commentaires pour clarifier l'intention des méthodes.
+- Remplacer les `try/except` génériques par des exceptions spécifiques avec logging.
+- Introduire des tests unitaires ou d'intégration pour les fonctionnalités clés.

--- a/code_reviews/ui_object_item_review.md
+++ b/code_reviews/ui_object_item_review.md
@@ -1,0 +1,18 @@
+# Revue de code : ui/object_item.py
+
+## Observations Générales
+- Fournit deux classes graphiques (`ObjectPixmapItem`, `ObjectSvgItem`) dérivées d'un mixin `_ObjectItemMixin` pour synchroniser l'état graphique avec le modèle.
+
+## Points Positifs
+- Synchronisation automatique des transformations avec le `SceneModel` via `itemChange`.
+- Gestion des erreurs avec logging en cas de problème lors de la mise à jour.
+
+## Problèmes Identifiés
+1. Aucun docstring ou commentaire explicatif sur le mixin et ses méthodes.
+2. Utilisation de `getattr` multiples pouvant être simplifiée.
+3. Mise à jour du modèle dans `itemChange` peut être coûteuse si de nombreux items changent fréquemment.
+
+## Recommandations
+- Ajouter des docstrings pour `_ObjectItemMixin` et les classes dérivées.
+- Refactoriser `itemChange` pour réduire l'imbrication et améliorer la lisibilité.
+- Évaluer l'impact performance des mises à jour instantanées ; envisager un batching.

--- a/code_reviews/ui_object_manager_review.md
+++ b/code_reviews/ui_object_manager_review.md
@@ -1,0 +1,24 @@
+# Revue de code : ui/object_manager.py
+
+## Observations Générales
+- Classe `ObjectManager` responsable de la création, suppression et manipulation des objets et pantins dans la scène.
+- Forte interaction avec `SceneModel`, `Puppet` et les éléments graphiques.
+
+## Points Positifs
+- Typage explicite (`Dict`, `Optional`, etc.) améliorant la lisibilité.
+- Les méthodes couvrent un large ensemble de fonctionnalités (ajout de pantins, duplication, captures d'état...).
+
+## Problèmes Identifiés
+1. Fichier volumineux (>400 lignes) sans segmentation logique en sous-modules.
+2. Quelques imports et commentaires inachevés (`# Added QGraphicsScene`, `# QSvgRenderer is not directly imported`).
+3. Usage fréquent de `if ...: statement` sur la même ligne, diminuant la clarté.
+4. Exceptions capturées sans log ou très génériques (`except Exception: pass`).
+5. Manque de docstrings pour la majorité des méthodes.
+6. Méthodes potentiellement redondantes ou très longues (`_add_puppet_graphics`, `capture_visible_object_states`).
+
+## Recommandations
+- Refactoriser en divisant la classe en plusieurs fichiers ou en introduisant des classes auxiliaires.
+- Supprimer les commentaires temporaires et clarifier les imports.
+- Respecter PEP8 en évitant les instructions multiples sur une même ligne.
+- Remplacer les `except Exception` par des exceptions spécifiques avec logging.
+- Ajouter des docstrings et tests unitaires pour les opérations critiques (snapshot, drop d'objets, etc.).

--- a/code_reviews/ui_playback_handler_review.md
+++ b/code_reviews/ui_playback_handler_review.md
@@ -1,0 +1,19 @@
+# Revue de code : ui/playback_handler.py
+
+## Observations Générales
+- Classe `PlaybackHandler` responsable de la gestion de la lecture et de la synchronisation entre le modèle, la timeline et l'inspecteur.
+- Utilise des signaux Qt pour dé-coupler la logique de lecture du reste de l'UI.
+
+## Points Positifs
+- Méthodes claires pour play/pause/stop, changement de frame et mise à jour du range.
+- Documentation de la classe via une docstring descriptive.
+
+## Problèmes Identifiés
+1. Absence de gestion d'erreurs ou de vérifications de bornes dans certaines méthodes (ex. `set_fps`).
+2. `next_frame` mélange logique métier et mise à jour de l'UI (`play_btn.setChecked`).
+3. Pas de tests unitaires couvrant ce gestionnaire.
+
+## Recommandations
+- Ajouter des validations pour les valeurs d'entrée (`fps`, `frame_index`).
+- Extraire la mise à jour de l'UI (`play_btn`) hors de `next_frame` pour respecter la séparation des responsabilités.
+- Introduire des tests pour la logique de boucle et de gestion de frames.

--- a/code_reviews/ui_scene_io_review.md
+++ b/code_reviews/ui_scene_io_review.md
@@ -1,0 +1,22 @@
+# Revue de code : ui/scene_io.py
+
+## Observations Générales
+- Fournit des fonctions utilitaires pour sauvegarder, charger et réinitialiser une scène.
+- Bonne séparation en fonctions (`save_scene`, `load_scene`, `export_scene`, etc.).
+- Docstrings présentes pour la plupart des fonctions.
+
+## Points Positifs
+- Gestion d'erreurs basique via `try/except` et utilisation du module `logging`.
+- Utilisation de `TYPE_CHECKING` pour éviter les importations circulaires.
+
+## Problèmes Identifiés
+1. Mélange d'utilisation de `print` et `logging` pour la gestion des erreurs ou messages utilisateur (`import_scene`).
+2. Certaines variables internes (`filePath`) utilisent une convention de nommage camelCase plutôt que snake_case.
+3. Les exceptions capturées dans `import_scene` sont très génériques (`Exception`).
+4. La fonction `create_blank_scene` a une ligne très longue combinant boucle et appel ; réduit la lisibilité.
+
+## Recommandations
+- Uniformiser les sorties console en privilégiant `logging`.
+- Renommer `filePath` en `file_path` pour respecter PEP8.
+- Spécifier les types d'exceptions attrapées pour améliorer le diagnostic.
+- Découper les lignes complexes pour améliorer la lisibilité et la maintenabilité.

--- a/code_reviews/ui_styles_review.md
+++ b/code_reviews/ui_styles_review.md
@@ -1,0 +1,19 @@
+# Revue de code : ui/styles.py
+
+## Observations Générales
+- Contient la feuille de style globale de l'application ainsi qu'une fonction `apply_stylesheet`.
+- L'accent est mis sur un thème clair avec couleurs pastel.
+
+## Points Positifs
+- Centralisation des styles facilitant la maintenance visuelle.
+- Gestion de la police via `QFont` avec fallback en cas d'absence de "Poppins".
+
+## Problèmes Identifiés
+1. Doublon de règles `DraggableHeader` (définies deux fois) pouvant créer de la confusion.
+2. Aucune documentation sur les conventions de nommage ou l'organisation des sections CSS.
+3. `print` utilisé dans `apply_stylesheet` au lieu de `logging`.
+
+## Recommandations
+- Supprimer ou fusionner les déclarations redondantes pour `DraggableHeader`.
+- Ajouter des commentaires ou une documentation décrivant les sections du stylesheet.
+- Utiliser `logging.warning` plutôt que `print` pour signaler l'absence de police.

--- a/code_reviews/ui_timeline_widget_review.md
+++ b/code_reviews/ui_timeline_widget_review.md
@@ -1,0 +1,21 @@
+# Revue de code : ui/timeline_widget.py
+
+## Observations Générales
+- Widget de timeline complet gérant lecture, keyframes, zoom et navigation.
+- Utilise une combinaison de boutons, sliders et événements de souris/clavier.
+
+## Points Positifs
+- Structure claire avec constantes définissant l'apparence (couleurs, tailles).
+- Signaux pour communiquer avec le reste de l'application (`frameChanged`, `fpsChanged`, etc.).
+
+## Problèmes Identifiés
+1. Absence de docstrings sur la classe et les méthodes, malgré la complexité du composant.
+2. Certaines lignes combinent plusieurs instructions séparées par des `;`, ce qui nuit à la lisibilité.
+3. Calculs de zoom et de scrolling dans `wheelEvent` sans limitation de plage explicite.
+4. Pas de tests unitaires pour ce widget complexe.
+
+## Recommandations
+- Ajouter des docstrings détaillées pour la classe et les méthodes principales.
+- Séparer les instructions multiples sur des lignes distinctes pour respecter PEP8.
+- Introduire des tests (par exemple, via `QTest`) pour valider les interactions clés.
+- Documenter ou limiter les valeurs de `_px_per_frame` pour éviter des comportements extrêmes.

--- a/code_reviews/ui_zoomable_view_review.md
+++ b/code_reviews/ui_zoomable_view_review.md
@@ -1,0 +1,22 @@
+# Revue de code : ui/zoomable_view.py
+
+## Observations Générales
+- Classe `ZoomableView` dérivée de `QGraphicsView` offrant zoom, drag & drop et superpositions d'outils.
+- Code structuré mais volumineux, mélangeant construction d'UI et logique d'interaction.
+
+## Points Positifs
+- Utilisation de signaux dédiés (`zoom_requested`, `item_dropped`, etc.) pour découpler la vue du reste de l'application.
+- Gestion de nombreux événements utilisateurs (souris, drag & drop, molette) avec prise en charge des modifiers.
+
+## Problèmes Identifiés
+1. Absence de docstrings sur la classe et la majorité des méthodes, rendant la compréhension difficile.
+2. Méthodes `_build_overlay` et `_build_main_tools_overlay` très longues ; pourraient être factorisées en sous-fonctions.
+3. `make_btn` interne dans `_build_overlay` et `_build_main_tools_overlay` crée des closures répétitives ; extraction possible.
+4. Gestion d'erreurs génériques dans `dropEvent` (`except Exception`).
+5. Aucun test automatisé pour ce composant malgré une logique complexe.
+
+## Recommandations
+- Ajouter des docstrings et commentaires pour expliquer la finalité de chaque méthode.
+- Refactoriser la construction des overlays en composants réutilisables ou fonctions externes.
+- Spécifier les exceptions attendues lors du parsing JSON dans `dropEvent`.
+- Introduire des tests (unitaires ou d'intégration) pour valider le comportement des interactions principales.


### PR DESCRIPTION
## Summary
- Crée un répertoire `code_reviews/` contenant une revue de code pour chaque fichier principal du projet
- Ajoute `actions_prioritaires.md` listant les améliorations à mener par ordre de priorité

## Testing
- `pip install -r requirements.txt`
- `pytest` *(échoue : tests de graphique et d'état d'objet)*

------
https://chatgpt.com/codex/tasks/task_e_689bc7c679e8832bbbae6efc76cfaca8