### PR TITLE
Add code review documents and action plan

### DIFF
--- a/code_reviews/actions_summary.md
+++ b/code_reviews/actions_summary.md
@@ -1,0 +1,28 @@
+# Plan d'actions priorisé
+
+1. **Corriger les imports manquants**
+   - `ui/styles.py` : ajouter `from PySide6.QtGui import QFont`.
+   - `ui/draggable_widget.py` : importer `QWidget`.
+   - `ui/icons.py` : ajouter `import re`.
+   - `tests/test_puppet_graphics.py` : ajouter `import os`.
+
+2. **Renforcer la documentation et les types**
+   - Ajouter docstrings et annotations de type aux classes et méthodes des modules `core` et `ui` (ex. `object_manager`, `timeline_widget`).
+   - Documenter les méthodes de tests pour clarifier l'intention.
+
+3. **Refactoriser les modules volumineux**
+   - `ui/main_window.py`, `ui/object_manager.py`, `ui/zoomable_view.py` : scinder en sous-modules ou classes pour réduire la complexité.
+   - Isoler la logique de timeline de la vue dans `ui/timeline_widget.py`.
+
+4. **Améliorer la gestion des erreurs et le logging**
+   - Remplacer les `print` par `logging` dans `core/svg_loader.py` et `ui/scene_io.py`.
+   - Affiner les blocs `try/except` génériques et fournir des messages de log explicites.
+
+5. **Étendre la couverture de tests**
+   - Ajouter des tests négatifs pour l'import/export de scènes.
+   - Tester le comportement du zoom, des overlays et de l'attachement des objets.
+   - Fermer explicitement les fenêtres créées dans les tests pour éviter les fuites de ressources.
+
+6. **Centraliser la configuration**
+   - Externaliser les grands dictionnaires (`PARENT_MAP`, `PIVOT_MAP`, `Z_ORDER`) et chemins de ressources dans des fichiers de configuration.
+   - Factoriser les constantes d'interface (couleurs, opacités, dimensions) dans un module dédié.

--- a/code_reviews/core_init.md
+++ b/code_reviews/core_init.md
@@ -1,0 +1,13 @@
+# Code Review : core/__init__.py
+
+## Points positifs
+- Fournit un point d'entrée unique pour importer les classes principales du module `core`.
+- Utilisation d'`__all__` pour contrôler l'API publique.
+
+## Points d'amélioration
+- Peu de documentation sur l'objectif global du paquet.
+- L'import direct des classes peut alourdir le temps de chargement si seules certaines sont nécessaires.
+
+## Recommandations
+- Ajouter un commentaire ou une docstring détaillant les responsabilités du sous-package `core`.
+- Évaluer l'opportunité d'imports paresseux (`lazy imports`) si le module devient volumineux.

--- a/code_reviews/core_puppet_model.md
+++ b/code_reviews/core_puppet_model.md
@@ -1,0 +1,18 @@
+# Code Review : core/puppet_model.py
+
+## Points positifs
+- Cartes `PARENT_MAP`, `PIVOT_MAP` et `Z_ORDER` claires pour définir la hiérarchie du pantin.
+- Classe `PuppetMember` bien structurée pour représenter chaque membre.
+- Fonctions utilitaires (`compute_child_map`, `validate_svg_structure`) facilitant la vérification des SVG.
+
+## Points d'amélioration
+- Les grands dictionnaires en début de fichier rendent la lecture difficile; envisager un chargement depuis un fichier de configuration.
+- Absence de docstrings pour plusieurs fonctions et classes.
+- `print` utilisé pour les audits au lieu de `logging`.
+- La fonction `main()` est incluse dans le module de modèle alors qu'elle relève davantage d'un script de démo.
+
+## Recommandations
+- Déplacer les données de configuration vers des fichiers externes pour permettre la réutilisation.
+- Documenter les méthodes clés (`build_from_svg`, `get_handle_target_pivot`, etc.).
+- Remplacer les `print` par des appels à `logging` et prévoir des niveaux de log.
+- Extraire la partie exécutable dans un script séparé pour conserver le module pur.

--- a/code_reviews/core_puppet_piece.md
+++ b/code_reviews/core_puppet_piece.md
@@ -1,0 +1,18 @@
+# Code Review : core/puppet_piece.py
+
+## Points positifs
+- Gestion précise des poignées de rotation et de pivot avec mise à jour automatique.
+- Utilisation de types `Optional` et `List` pour clarifier les attributs.
+- Séparation entre `RotationHandle` et `PivotHandle` pour une meilleure lisibilité.
+
+## Points d'amélioration
+- Peu de docstrings expliquant le rôle des classes et méthodes.
+- Certains imports (ex. `Any`) sont génériques; l'utilisation de types plus précis améliorerait la maintenabilité.
+- Les constantes de couleurs pourraient être centralisées pour assurer la cohérence du thème.
+- La logique de calcul d'angles se répète dans les événements de souris; extraire une méthode utilitaire.
+
+## Recommandations
+- Ajouter des docstrings détaillant les interactions des poignées avec la scène.
+- Introduire des annotations de type complètes, notamment pour les valeurs de retour.
+- Factoriser la logique commune des événements pour faciliter les futurs changements.
+- Ajouter des tests unitaires ciblant `rotate_piece` et `update_transform_from_parent`.

--- a/code_reviews/core_scene_model.md
+++ b/code_reviews/core_scene_model.md
@@ -1,0 +1,18 @@
+# Code Review : core/scene_model.py
+
+## Points positifs
+- Modèle de scène structuré avec classes `SceneObject` et `Keyframe` clairement définies.
+- Méthodes d'import/export JSON permettant la persistance de l'état.
+- Utilisation de `logging` pour signaler les erreurs lors du chargement.
+
+## Points d'amélioration
+- De nombreuses méthodes manquent de docstrings détaillant les paramètres et valeurs de retour.
+- La méthode `import_json` contient un appel `self.from_dict(data)` après un `return False`, code mort à corriger.
+- Les attributs de `SceneModel` ne sont pas typés; l'introduction de `Dict[str, SceneObject]` etc. clarifierait le modèle.
+- `add_keyframe` mélange la capture d'état et la gestion de la structure; séparer ces responsabilités.
+
+## Recommandations
+- Ajouter des annotations de type et docstrings pour toutes les méthodes publiques.
+- Corriger la structure de `import_json` pour éviter le code inatteignable et retourner explicitement le succès.
+- Envisager l'utilisation de dataclasses pour `SceneObject` et `Keyframe` afin de réduire le code boilerplate.
+- Couvrir l'import/export avec des tests supplémentaires (ex : valeurs de `background_path`).

--- a/code_reviews/core_svg_loader.md
+++ b/code_reviews/core_svg_loader.md
@@ -1,0 +1,16 @@
+# Code Review : core/svg_loader.py
+
+## Points positifs
+- Classe `SvgLoader` bien structurée pour manipuler les SVG avec `QSvgRenderer`.
+- Méthodes utilitaires (`get_groups`, `get_pivot`, `extract_group`) facilitent l'extraction de ressources.
+- Usage cohérent des annotations de type et des retours optionnels.
+
+## Points d'amélioration
+- Peu de gestion d'exceptions lors du parsing des fichiers SVG; une erreur de fichier corrompu pourrait lever une exception non gérée.
+- `print` utilisé dans `extract_group` pour informer l'utilisateur; privilégier `logging`.
+- La fonction `translate_path` repose sur une expression régulière simplifiée pouvant échouer sur des commandes SVG complexes.
+
+## Recommandations
+- Ajouter des blocs `try/except` autour des opérations de lecture/écriture pour améliorer la robustesse.
+- Remplacer les `print` par des logs paramétrables.
+- Documenter les limitations de `translate_path` ou envisager l'utilisation d'une bibliothèque spécialisée pour manipuler les paths.

--- a/code_reviews/macronotron.md
+++ b/code_reviews/macronotron.md
@@ -1,0 +1,15 @@
+# Code Review : macronotron.py
+
+## Points positifs
+- Point d'entrée clair et minimaliste pour l'application.
+- Utilisation d'un thème via `apply_stylesheet` pour homogénéiser l'interface.
+
+## Points d'amélioration
+- Le module `logging` est importé mais jamais utilisé.
+- Absence de gestion d'erreurs lors de l'initialisation de l'application.
+- Toute la logique est dans le bloc `if __name__ == "__main__"`; une fonction `main()` faciliterait les tests.
+
+## Recommandations
+- Supprimer l'import inutile ou ajouter des logs informatifs.
+- Envelopper la création de l'application dans une fonction afin de pouvoir l'appeler depuis les tests.
+- Prévoir un mécanisme de configuration ou d'argumentation en ligne de commande pour plus de flexibilité.

--- a/code_reviews/tests_test_object_keyframe_states.md
+++ b/code_reviews/tests_test_object_keyframe_states.md
@@ -1,0 +1,15 @@
+# Code Review : tests/test_object_keyframe_states.py
+
+## Points positifs
+- Vérifie que les états des objets sont correctement enregistrés dans les keyframes et restaurés.
+- Utilise `pytest` et `QApplication` avec un fixture pour gérer le contexte Qt.
+
+## Points d'amélioration
+- L'environnement offscreen n'est pas forcé (contrairement à d'autres tests), ce qui peut poser problème en CI sans serveur X.
+- Le test crée une `MainWindow` mais ne la ferme jamais explicitement; risque de fuites de ressources.
+- `sys.path.append` utilisé pour gérer l'import; préférer une configuration de package ou `PYTHONPATH`.
+
+## Recommandations
+- Ajouter `os.environ["QT_QPA_PLATFORM"] = "offscreen"` en haut du fichier ou dans le fixture `app`.
+- Fermer explicitement la fenêtre (`win.close()`) à la fin du test pour libérer les ressources.
+- Configurer les imports via `pytest.ini` ou l'installation du package pour éviter la manipulation de `sys.path`.

--- a/code_reviews/tests_test_puppet_graphics.md
+++ b/code_reviews/tests_test_puppet_graphics.md
@@ -1,0 +1,15 @@
+# Code Review : tests/test_puppet_graphics.py
+
+## Points positifs
+- Vérifie la hiérarchie des pièces du pantin ainsi que la propagation des transformations.
+- Utilise le mode offscreen pour exécuter les tests sans interface graphique.
+
+## Points d'amélioration
+- Le module `os` n'est pas importé alors qu'il est utilisé pour définir `QT_QPA_PLATFORM`.
+- Les instances de `MainWindow` ne sont pas fermées explicitement, ce qui peut laisser des ressources non libérées.
+- Les assertions ne couvrent pas la remise à zéro des rotations ou la cohérence des z-order après transformations.
+
+## Recommandations
+- Ajouter `import os` en tête de fichier.
+- Fermer la fenêtre (`window.close()`) à la fin de chaque test.
+- Étendre les tests pour couvrir d'autres membres du pantin et vérifier les z-order.

--- a/code_reviews/tests_test_scene_model_io.md
+++ b/code_reviews/tests_test_scene_model_io.md
@@ -1,0 +1,13 @@
+# Code Review : tests/test_scene_model_io.py
+
+## Points positifs
+- Couvre la sérialisation/desérialisation d'un `SceneObject` et le cycle complet d'export/import de `SceneModel`.
+- Utilisation de `tmp_path` de pytest pour gérer les fichiers temporaires.
+
+## Points d'amélioration
+- Les tests ne vérifient pas l'export des `puppets` ni des paramètres de scène (taille, fps...).
+- Absence de tests négatifs (fichier corrompu, valeurs manquantes) pour valider la robustesse.
+
+## Recommandations
+- Ajouter des assertions sur les champs `background_path` et sur la liste des puppets exportés.
+- Tester l'import de fichiers invalides pour s'assurer que `SceneModel.import_json` gère correctement les erreurs.

--- a/code_reviews/ui_draggable_widget.md
+++ b/code_reviews/ui_draggable_widget.md
@@ -1,0 +1,16 @@
+# Code Review : ui/draggable_widget.py
+
+## Points positifs
+- Fournit des overlays déplaçables et redimensionnables utilisables dans différentes parties de l'UI.
+- Gestion soignée des effets d'ombre et du redimensionnement via les coins.
+- Classes bien séparées (`DraggableOverlay`, `PanelOverlay`, `DraggableHeader`).
+
+## Points d'amélioration
+- Le module n'importe pas `QWidget` alors qu'il est utilisé comme classe de base.
+- Absence de docstrings pour les méthodes, ce qui limite la compréhension des comportements.
+- Certaines sections utilisent des `event.position()` (Qt6) sans vérification de compatibilité Qt5.
+
+## Recommandations
+- Ajouter les imports manquants (`from PySide6.QtWidgets import QWidget`).
+- Documenter les interactions utilisateur attendues (clic droit vs gauche, zones de redimensionnement).
+- Ajouter des tests unitaires de base pour valider le comportement de glisser-déposer et de redimensionnement.

--- a/code_reviews/ui_icons.md
+++ b/code_reviews/ui_icons.md
@@ -1,0 +1,16 @@
+# Code Review : ui/icons.py
+
+## Points positifs
+- Mise en cache des icônes pour éviter le rendu multiple des SVG.
+- Fonction `_render_svg` séparée pour gérer la conversion SVG → QPixmap.
+- Interface publique simple (`get_icon` et fonctions alias).
+
+## Points d'amélioration
+- Le module utilise `re.sub` sans importer le module `re`.
+- Les icônes sont recolorées via une regex simple qui pourrait échouer sur des SVG plus complexes.
+- Absence de gestion d'erreur lors de la lecture des fichiers SVG; un fichier manquant retourne simplement une icône vide.
+
+## Recommandations
+- Ajouter `import re` en haut du fichier.
+- Valider l'existence et la validité des SVG avec des messages de log explicites.
+- Prévoir un mécanisme pour définir les couleurs via la configuration plutôt que dans le code.

--- a/code_reviews/ui_inspector_widget.md
+++ b/code_reviews/ui_inspector_widget.md
@@ -1,0 +1,18 @@
+# Code Review : ui/inspector_widget.py
+
+## Points positifs
+- Interface complète pour gérer objets et pantins via une liste et divers contrôles.
+- Bonne utilisation des signaux Qt pour synchroniser l'UI avec le modèle.
+- Structure claire des layouts avec séparateurs pour améliorer l'ergonomie.
+
+## Points d'amélioration
+- Fichier volumineux combinant création de widgets, callbacks et logique métier; la lisibilité en souffre.
+- Plusieurs méthodes privées n'ont pas d'annotations de type ni de docstrings.
+- La fonction `_attached_state_for_frame` contient des variables peu explicites (`si`, `prev`), rendant la logique difficile à suivre.
+- Aucune gestion d'erreur lors de l'accès aux structures du modèle (`get` sans vérification de retour).
+
+## Recommandations
+- Scinder certaines parties (par ex. gestion des attachments) dans des helpers dédiés.
+- Ajouter des docstrings et annotations de type pour les méthodes privées.
+- Renommer les variables pour refléter leur rôle et commenter les sections complexes.
+- Envisager des tests d'intégration pour garantir la synchronisation UI ↔ modèle.

--- a/code_reviews/ui_library_widget.md
+++ b/code_reviews/ui_library_widget.md
@@ -1,0 +1,16 @@
+# Code Review : ui/library_widget.py
+
+## Points positifs
+- Interface de bibliothèque avec drag-and-drop permettant d'ajouter facilement des ressources.
+- Séparation par catégories (arrière-plans, objets, pantins) via un `QTabWidget`.
+- Utilisation de `payload` JSON pour transporter les métadonnées lors du glisser-déposer.
+
+## Points d'amélioration
+- Très peu de docstrings; certaines méthodes comme `reload` mériteraient une description.
+- Gestion d'erreur minimale lors du chargement des icônes ou des fichiers inexistants.
+- Les chemins d'accès (`asset_dirs`) sont codés en dur; une configuration externe améliorerait la portabilité.
+
+## Recommandations
+- Ajouter des docstrings et annotations de type pour clarifier l'API de `_DraggableGrid` et `LibraryWidget`.
+- Enrichir la gestion d'erreurs (fichiers manquants, formats non supportés) avec des logs.
+- Paramétrer les répertoires racine via un fichier de configuration ou des arguments.

--- a/code_reviews/ui_main_window.md
+++ b/code_reviews/ui_main_window.md
@@ -1,0 +1,18 @@
+# Code Review : ui/main_window.py
+
+## Points positifs
+- Classe centrale orchestrant la scène, la timeline, les overlays et la gestion des objets.
+- Bonne séparation des responsabilités via des gestionnaires (`ObjectManager`, `PlaybackHandler`).
+- Utilisation de `QSettings` pour persister certaines préférences utilisateur.
+
+## Points d'amélioration
+- Fichier extrêmement volumineux (>1000 lignes) mêlant création de widgets, logique métier et comportements UI complexes.
+- Manque de docstrings et d'annotations de type pour la majorité des méthodes, rendant le code difficile à comprendre.
+- Plusieurs blocs `try/except` silencieux; les erreurs sont parfois ignorées.
+- Usage de nombreuses valeurs magiques (positions, facteurs d'opacité) sans constantes nommées.
+
+## Recommandations
+- Extraire des composants (gestion des overlays, onion skin, commandes de menus) dans des classes ou modules dédiés.
+- Documenter les méthodes publiques et ajouter des annotations de type pour faciliter la maintenance.
+- Centraliser les constantes (opacités, positions initiales) dans un module de configuration.
+- Ajouter des tests d'intégration pour valider la cohérence entre modèle et vue (ex : `update_scene_from_model`).

--- a/code_reviews/ui_object_item.md
+++ b/code_reviews/ui_object_item.md
@@ -1,0 +1,16 @@
+# Code Review : ui/object_item.py
+
+## Points positifs
+- Utilisation d'un mixin (`_ObjectItemMixin`) pour partager la logique entre les items pixmap et SVG.
+- Synchronisation automatique de la position/rotation avec le modèle lors de `itemChange`.
+- Intégration avec l'inspecteur lorsqu'un item est sélectionné.
+
+## Points d'amélioration
+- Aucun docstring pour expliquer le rôle du mixin et les méthodes override.
+- Pas de gestion d'erreur fine dans `itemChange`; une exception peut interrompre l'interaction utilisateur.
+- Les classes publiques (`ObjectPixmapItem`, `ObjectSvgItem`) pourraient être typées (retours, paramètres).
+
+## Recommandations
+- Ajouter des docstrings décrivant l'objectif du mixin et des classes dérivées.
+- Limiter la portée du `try/except` dans `itemChange` et enregistrer les erreurs via `logging`.
+- Ajouter des annotations de type pour clarifier l'API des constructeurs.

--- a/code_reviews/ui_object_manager.md
+++ b/code_reviews/ui_object_manager.md
@@ -1,0 +1,18 @@
+# Code Review : ui/object_manager.py
+
+## Points positifs
+- Gestion centralisée des objets et des pantins, permettant la synchronisation entre modèle et scène graphique.
+- Utilisation de dictionnaires (`graphics_items`, `renderers`, `puppet_scales`) pour suivre l'état interne.
+- Méthodes spécialisées pour la capture des états (`capture_puppet_states`, `snapshot_current_frame`).
+
+## Points d'amélioration
+- Fichier très long et dense; plusieurs responsabilités pourraient être réparties dans des modules distincts (chargement, duplication, snapshot).
+- De nombreuses méthodes n'ont pas de docstrings ni d'annotations de type précises.
+- Usage fréquent de `Any` et de cast implicites; ceci complique la compréhension et la vérification statique.
+- Les bloc `try/except` silencieux peuvent masquer des erreurs (ex. dans `_add_puppet_graphics`).
+
+## Recommandations
+- Refactoriser en plusieurs classes ou utilitaires (ex. `PuppetFactory`, `KeyframeService`).
+- Ajouter des docstrings et des types de retour pour chaque méthode publique.
+- Remplacer les `except Exception:` génériques par des exceptions plus ciblées ou au moins un logging.
+- Introduire des tests unitaires pour valider la duplication, l'attachement et la capture d'état.

--- a/code_reviews/ui_playback_handler.md
+++ b/code_reviews/ui_playback_handler.md
@@ -1,0 +1,16 @@
+# Code Review : ui/playback_handler.py
+
+## Points positifs
+- Séparation claire de la logique de lecture (`play`, `pause`, `next_frame`) du reste de la fenêtre principale.
+- Usage intensif des signaux pour communiquer avec d'autres composants.
+- Gestion du mode boucle et du réglage de FPS intégrée.
+
+## Points d'amélioration
+- Peu de docstrings sur les méthodes publiques, rendant l'intention moins évidente.
+- `go_to_frame` effectue une sauvegarde conditionnelle puis met à jour l'état; un découpage en méthodes plus petites faciliterait les tests.
+- Absence de contrôle sur des valeurs aberrantes (ex. FPS à 0 dans `set_fps`).
+
+## Recommandations
+- Ajouter des docstrings et des annotations de type de retour pour chaque méthode.
+- Introduire des vérifications d'arguments (FPS positifs, plages valides) avec gestion d'erreur.
+- Couvrir la logique de lecture par des tests unitaires afin de garantir la précision des incréments de frame.

--- a/code_reviews/ui_scene_io.md
+++ b/code_reviews/ui_scene_io.md
@@ -1,0 +1,18 @@
+# Code Review : ui/scene_io.py
+
+## Points positifs
+- Fonctions séparées pour sauvegarder, charger, exporter et importer la scène.
+- Utilisation du modèle pour récupérer l'état (`scene_model.to_dict`).
+- Gestion basique des erreurs via `logging` lors de l'export.
+
+## Points d'amélioration
+- L'import de `logging` est placé en milieu de fichier, ce qui n'est pas conventionnel.
+- Les fonctions `save_scene` et `load_scene` n'ont pas de gestion d'erreur si l'utilisateur annule la boîte de dialogue.
+- `import_scene` contient un bloc `try/except` très large où les exceptions sont simplement affichées; l'état du programme peut rester incohérent.
+- Manque de docstrings pour `create_blank_scene` et absence d'annotations de type de retour.
+
+## Recommandations
+- Déplacer l'import de `logging` en haut du fichier et structurer les `try/except` pour traiter les erreurs spécifiques.
+- Retourner un booléen indiquant le succès des opérations pour faciliter les tests.
+- Ajouter des annotations de type et des docstrings pour tous les helpers.
+- Externaliser certaines responsabilités (reconstruction de la scène) dans des services dédiés pour réduire la taille de `import_scene`.

--- a/code_reviews/ui_styles.md
+++ b/code_reviews/ui_styles.md
@@ -1,0 +1,15 @@
+# Code Review : ui/styles.py
+
+## Points positifs
+- Centralisation du thème via une feuille de style exhaustive.
+- Mise en place d'une fonction `apply_stylesheet` pour appliquer les paramètres globaux.
+
+## Points d'amélioration
+- L'import de `QFont` manque alors qu'il est utilisé dans `apply_stylesheet`.
+- Certaines règles CSS sont dupliquées (par exemple `DraggableHeader` est défini deux fois avec des styles différents).
+- La constante `ICON_COLOR` n'est pas utilisée dans le fichier.
+
+## Recommandations
+- Ajouter l'import manquant et gérer le cas d'absence de police plus élégamment (logging plutôt que `print`).
+- Factoriser les règles CSS répétées afin d'éviter les incohérences.
+- Retirer ou utiliser `ICON_COLOR` pour éviter les constantes mortes.

--- a/code_reviews/ui_timeline_widget.md
+++ b/code_reviews/ui_timeline_widget.md
@@ -1,0 +1,17 @@
+# Code Review : ui/timeline_widget.py
+
+## Points positifs
+- Widget de timeline complet avec lecture, gestion de keyframes et zoom.
+- Signalisation riche (`frameChanged`, `addKeyframeClicked`, etc.) permettant l'intégration avec d'autres composants.
+- Rendu personnalisé via `paintEvent` pour visualiser la timeline.
+
+## Points d'amélioration
+- Le fichier mêle UI, logique de timeline et gestion des raccourcis clavier dans une seule classe.
+- Absence quasi totale de docstrings sur les méthodes privées, rendant l'algorithme difficile à appréhender.
+- Certaines constantes (`RULER_H`, `TRACK_H`) pourraient être regroupées dans une configuration ou une énumération.
+- Gestion manuelle des conversions coordonnées↔frames; une abstraction pourrait réduire la complexité.
+
+## Recommandations
+- Documenter les méthodes clés (`_draw_ticks`, `_frame_to_x`, `_x_to_frame`) avec des exemples.
+- Envisager de séparer la logique de timeline (calculs, conversion) de la vue pour faciliter les tests.
+- Ajouter des tests unitaires couvrant la navigation de frames et la manipulation de keyframes.

--- a/code_reviews/ui_zoomable_view.md
+++ b/code_reviews/ui_zoomable_view.md
@@ -1,0 +1,18 @@
+# Code Review : ui/zoomable_view.py
+
+## Points positifs
+- Widget de vue enrichi avec commandes de zoom, fit et gestion de l'onion skin.
+- Utilisation judicieuse d'un overlay glissable pour regrouper les boutons de contrôle.
+- Gestion complète des événements de souris et de drag-and-drop.
+
+## Points d'amélioration
+- Fichier volumineux avec beaucoup de logique dans `__init__` et `_build_overlay`; difficile à maintenir.
+- Manque de docstrings sur les méthodes, notamment celles gérant les événements.
+- Certaines méthodes mettent à jour des attributs créés dynamiquement (`_panning`, `_main_tools_overlay`) sans déclaration préalable.
+- Absence de tests unitaires pour les interactions complexes (zoom, overlay repliable).
+
+## Recommandations
+- Scinder la construction de l'overlay et des outils principaux dans des classes ou fonctions séparées.
+- Ajouter des annotations de type et documenter les interactions de drag-and-drop.
+- Initialiser explicitement les attributs utilisés dans les méthodes pour éviter les erreurs de typage.
+- Ajouter des tests automatisés pour vérifier le comportement du zoom et des boutons.


### PR DESCRIPTION
## Summary
- Add detailed code review reports for all Python modules.
- Compile a prioritized action plan derived from the reviews.

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: assertion mismatch in `test_object_state_is_per_keyframe`, KeyError in puppet graphics tests)*

------
https://chatgpt.com/codex/tasks/task_e_689bc7c679e8832bbbae6efc76cfaca8