### PR TITLE
Centralize scene state capture in ObjectManager

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -130,6 +130,8 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
 - Centralisation des poignées de rotation: `SceneController.set_rotation_handles_visible` gère désormais l'affichage des poignées de rotation au lieu de `MainWindow`. Un test unitaire couvre également `SceneController.set_scene_size`.
 - **Centralisation de la logique de scène** : Les méthodes de manipulation de la scène (ajout/suppression/duplication d'objets et de marionnettes) ont été déplacées de `ObjectManager` vers `SceneController` pour une meilleure séparation des responsabilités. `ObjectManager` se concentre désormais sur la gestion des données des objets et des marionnettes, tandis que `SceneController` gère leur représentation et leur manipulation dans la scène.
 
+- Capture de scène unifiée : `ObjectManager` expose désormais `capture_scene_state`, permettant à `SceneModel.add_keyframe` de recevoir directement les états des objets et marionnettes sans dupliquer la logique de sérialisation.
+
 - Refactor `SceneObject` et `Keyframe` : conversion en `dataclasses` afin de simplifier l'initialisation et la sérialisation.
 
 ## État actuel et prochaines étapes possibles

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -244,12 +244,8 @@ class MainWindow(QMainWindow):
 
     def add_keyframe(self, frame_index: int) -> None:
         """Adds a keyframe to the scene."""
-        puppet_states: Dict[str, Dict[str, Dict[str, Any]]] = self.object_manager.capture_puppet_states()
-        self.scene_model.add_keyframe(frame_index, puppet_states)
-        # Overwrite objects with the on-screen capture so we don't serialize stale/global attachment
-        kf: Optional[Keyframe] = self.scene_model.keyframes.get(frame_index)
-        if kf is not None:
-            kf.objects = self.object_manager.capture_visible_object_states()
+        state = self.object_manager.capture_scene_state()
+        self.scene_model.add_keyframe(frame_index, state)
         self.timeline_widget.add_keyframe_marker(frame_index)
 
     def select_object_in_inspector(self, name: str) -> None:

--- a/ui/object_manager.py
+++ b/ui/object_manager.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Any
 
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsScene # Added QGraphicsScene
 
-from core.scene_model import Keyframe, SceneModel
+from core.scene_model import SceneModel
 from core.puppet_piece import PuppetPiece
 
 if TYPE_CHECKING:
@@ -78,19 +78,18 @@ class ObjectManager:
                 states[name] = data
         return states
 
+    def capture_scene_state(self) -> Dict[str, Dict[str, Any]]:
+        """Capture both puppet and visible object states."""
+        return {
+            "puppets": self.capture_puppet_states(),
+            "objects": self.capture_visible_object_states(),
+        }
+
     def snapshot_current_frame(self) -> None:
         """Snapshots the current frame."""
         cur: int = self.scene_model.current_frame
-        puppet_states = self.capture_puppet_states()
-        obj_states = self.capture_visible_object_states()
-        kf: Optional[Keyframe] = self.scene_model.keyframes.get(cur)
-        if kf is None:
-            kf = Keyframe(cur)
-        kf.puppets = puppet_states
-        kf.objects = obj_states
-        self.scene_model.keyframes[cur] = kf
-        # Keep keyframes sorted
-        self.scene_model.keyframes = dict(sorted(self.scene_model.keyframes.items()))
+        state = self.capture_scene_state()
+        self.scene_model.add_keyframe(cur, state)
         # Ensure marker exists
         try:
             self.win.timeline_widget.add_keyframe_marker(cur)


### PR DESCRIPTION
## Summary
- Let `SceneModel.add_keyframe` accept captured puppet and object states
- Expose `ObjectManager.capture_scene_state` and reuse it in snapshot and keyframe additions
- Streamline `MainWindow.add_keyframe` to rely on unified scene capture
- Document unified scene capture in STATE_OF_THE_ART

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f059ffa80832ba1b4095c0553e15b