### PR TITLE
refactor: rename filePath variables

### DIFF
--- a/ui/scene/actions.py
+++ b/ui/scene/actions.py
@@ -17,15 +17,15 @@ def reset_scene(win: Any) -> None:
 
 def set_background(win: Any) -> None:
     """Open a file dialog to choose a background image and apply it."""
-    filePath: str
-    filePath, _ = QFileDialog.getOpenFileName(
+    file_path: str
+    file_path, _ = QFileDialog.getOpenFileName(
         win,
         "Charger une image d'arrière-plan",
         "",
         "Images (*.png *.jpg *.jpeg)",
     )
-    if filePath:
-        win.scene_controller.set_background_path(filePath)
+    if file_path:
+        win.scene_controller.set_background_path(file_path)
 
 def set_scene_size(win) -> None:
     """Prompt the user for scene width/height and apply to the scene.

--- a/ui/scene/scene_io.py
+++ b/ui/scene/scene_io.py
@@ -14,17 +14,17 @@ if TYPE_CHECKING:
 
 def save_scene(win: 'MainWindow') -> None:
     """Opens a dialog to save the current scene to a JSON file."""
-    filePath: str
-    filePath, _ = QFileDialog.getSaveFileName(win, "Sauvegarder la scène", "", "JSON Files (*.json)")
-    if filePath:
-        export_scene(win, filePath)
+    file_path: str
+    file_path, _ = QFileDialog.getSaveFileName(win, "Sauvegarder la scène", "", "JSON Files (*.json)")
+    if file_path:
+        export_scene(win, file_path)
 
 def load_scene(win: 'MainWindow') -> None:
     """Opens a dialog to load a scene from a JSON file."""
-    filePath: str
-    filePath, _ = QFileDialog.getOpenFileName(win, "Charger une scène", "", "JSON Files (*.json)")
-    if filePath:
-        import_scene(win, filePath)
+    file_path: str
+    file_path, _ = QFileDialog.getOpenFileName(win, "Charger une scène", "", "JSON Files (*.json)")
+    if file_path:
+        import_scene(win, file_path)
 
 def export_scene(win: 'MainWindow', file_path: str) -> None:
     """Exports the current scene state to a JSON file."""


### PR DESCRIPTION
## Summary
- rename temporary filePath variables to file_path in scene actions
- align scene_io save/load helpers with snake_case file_path

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f27e5606c832b9eb83a6c1cb38ab9