### PR TITLE
Refactor puppet transforms with QTransform

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -137,6 +137,7 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
 
 - Renforcement du traitement d'erreurs : remplacement des `except Exception` génériques par des exceptions ciblées ou des journaux détaillés.
 - Typage renforcé : introduction de `MainWindowProtocol` pour documenter les attributs attendus par `SceneController` et éliminer l'usage de `Any`.
+- Calcul des transformations des membres : remplacement des trigonométries manuelles par `QTransform` pour composer rotation et translation des pantins.
 
 ## État actuel et prochaines étapes possibles
 

--- a/core/puppet_piece.py
+++ b/core/puppet_piece.py
@@ -7,7 +7,7 @@ import math
 from PySide6.QtWidgets import QGraphicsEllipseItem, QGraphicsSceneMouseEvent, QGraphicsItem
 from PySide6.QtSvgWidgets import QGraphicsSvgItem
 from PySide6.QtCore import Qt, QPointF
-from PySide6.QtGui import QBrush, QPen, QColor
+from PySide6.QtGui import QBrush, QPen, QColor, QTransform
 from PySide6.QtSvg import QSvgRenderer # Added for type hinting
 
 # --- Constantes ---
@@ -176,16 +176,14 @@ class PuppetPiece(QGraphicsSvgItem):
 
         parent: 'PuppetPiece' = self.parent_piece
         parent_rotation: float = parent.rotation()
-        angle_rad: float = math.radians(parent_rotation)
         dx, dy = self.rel_to_parent
-        cos_a: float = math.cos(angle_rad)
-        sin_a: float = math.sin(angle_rad)
-        rotated_dx: float = dx * cos_a - dy * sin_a
-        rotated_dy: float = dx * sin_a + dy * cos_a
+        transform: QTransform = QTransform()
+        transform.rotate(parent_rotation)
+        transform.translate(dx, dy)
+        offset: QPointF = transform.map(QPointF(0.0, 0.0))
         parent_pivot: QPointF = parent.mapToScene(parent.transformOriginPoint())
-        scene_x: float = parent_pivot.x() + rotated_dx
-        scene_y: float = parent_pivot.y() + rotated_dy
-        self.setPos(scene_x - self.pivot_x, scene_y - self.pivot_y)
+        scene_pos: QPointF = parent_pivot + offset - QPointF(self.pivot_x, self.pivot_y)
+        self.setPos(scene_pos)
         self.setRotation(parent_rotation + self.local_rotation)
         self.update_handle_positions()
         for child in self.children:

--- a/tests/test_puppet_graphics.py
+++ b/tests/test_puppet_graphics.py
@@ -46,6 +46,8 @@ def test_hierarchy_and_pivot(app):
     forearm_pos_after = forearm.mapToScene(forearm.transformOriginPoint())
     assert elbow_pos_after.x() == pytest.approx(forearm_pos_after.x())
     assert elbow_pos_after.y() == pytest.approx(forearm_pos_after.y())
+    assert elbow.rotation() == pytest.approx(45)
+    assert forearm.rotation() == pytest.approx(45)
 
     # L'ordre d'affichage reste celui défini manuellement
     assert upper.zValue() == Z_ORDER.get("haut_bras_droite", -1)


### PR DESCRIPTION
## Summary
- Use `QTransform` to compose rotation and translation for child puppet pieces
- Verify propagated rotation in graphics tests
- Document new transformation approach

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2e80f214832bb582ab10b2d34c2a