### PR TITLE
Add tests for timeline widget and object manager

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_object_manager.py
+++ b/tests/test_object_manager.py
@@ -1,0 +1,44 @@
+import os
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+import pytest
+from PySide6.QtWidgets import QApplication
+from pathlib import Path
+
+from ui.main_window import MainWindow
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_capture_visible_object_states(app):
+    win = MainWindow()
+    win.scene_controller.add_puppet(str(Path("assets/pantins/manu.svg").resolve()), "manu")
+
+    free_path = str(Path("assets/objets/Faucille.svg").resolve())
+    free_name = win.scene_controller._create_object_from_file(free_path)
+    free_item = win.object_manager.graphics_items[free_name]
+    free_item.setPos(100.0, 200.0)
+
+    attached_path = str(Path("assets/objets/Marteau.svg").resolve())
+    attached_name = win.scene_controller._create_object_from_file(attached_path)
+    win.scene_controller.attach_object_to_member(attached_name, "manu", "main_droite")
+    attached_item = win.object_manager.graphics_items[attached_name]
+    attached_item.setPos(10.0, 20.0)
+
+    states = win.object_manager.capture_visible_object_states()
+
+    free_state = states.get(free_name)
+    attached_state = states.get(attached_name)
+    assert free_state is not None and attached_state is not None
+    assert free_state["attached_to"] in (None,)
+    assert free_state["x"] == pytest.approx(100.0)
+    assert free_state["y"] == pytest.approx(200.0)
+    assert attached_state["attached_to"] == ("manu", "main_droite")
+    assert attached_state["x"] == pytest.approx(10.0)
+    assert attached_state["y"] == pytest.approx(20.0)

--- a/tests/test_timeline_widget.py
+++ b/tests/test_timeline_widget.py
@@ -1,0 +1,48 @@
+import os
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QPointF, QPoint, Qt
+from PySide6.QtGui import QWheelEvent
+
+from ui.timeline_widget import TimelineWidget
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_add_keyframe_marker_and_navigation(app):
+    tw = TimelineWidget()
+    tw.add_keyframe_marker(5)
+    tw.add_keyframe_marker(10)
+    assert 5 in tw._kfs and 10 in tw._kfs
+
+    tw.set_current_frame(7)
+    tw.prev_kf_btn.click()
+    assert tw._current == 5
+    tw.next_kf_btn.click()
+    assert tw._current == 10
+    tw.next_kf_btn.click()
+    assert tw._current == 5
+
+
+def test_zoom_with_wheel_event(app):
+    tw = TimelineWidget()
+    tw.resize(400, 100)
+    initial = tw._px_per_frame
+    ev_in = QWheelEvent(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, 120),
+                        Qt.NoButton, Qt.ControlModifier, Qt.ScrollBegin, False)
+    tw.wheelEvent(ev_in)
+    zoomed = tw._px_per_frame
+    assert zoomed > initial
+
+    ev_out = QWheelEvent(QPointF(0, 0), QPointF(0, 0), QPoint(0, 0), QPoint(0, -120),
+                         Qt.NoButton, Qt.ControlModifier, Qt.ScrollBegin, False)
+    tw.wheelEvent(ev_out)
+    assert tw._px_per_frame < zoomed


### PR DESCRIPTION
## Summary
- ensure tests can import project modules by adding tests/conftest.py
- add timeline widget tests for keyframe markers, navigation and zoom
- add object manager tests covering capture_visible_object_states for free and attached objects

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f39307888832bb09d744dc3d972bd