### PR TITLE
refactor: extract make_tool_button helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,20 @@ import sys
 import os
 from pathlib import Path
 
+import pytest
+from PySide6.QtWidgets import QApplication
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+
+@pytest.fixture(scope="module")
+def _app():
+    """Provide a ``QApplication`` instance for UI tests."""
+    qapp = QApplication.instance()
+    if qapp is None:
+        qapp = QApplication([])
+    return qapp

--- a/tests/test_ui_utils.py
+++ b/tests/test_ui_utils.py
@@ -1,0 +1,32 @@
+"""Tests for UI utility helpers."""
+
+from PySide6.QtCore import QSize
+from PySide6.QtWidgets import QWidget
+
+from ui.icons import icon_plus
+from ui.utils import make_tool_button
+
+
+def test_make_tool_button_basic(_app):
+    """Ensure ``make_tool_button`` configures a button correctly."""
+    clicked = []
+
+    def on_click():
+        clicked.append(True)
+
+    parent = QWidget()
+    btn = make_tool_button(
+        parent,
+        icon=icon_plus(),
+        tooltip="Add",
+        callback=on_click,
+        checkable=True,
+    )
+
+    assert btn.toolTip() == "Add"
+    assert btn.isCheckable()
+    assert btn.iconSize() == QSize(32, 32)
+    assert btn.width() == max(28, 32 + 4)
+
+    btn.click()
+    assert clicked

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -1,0 +1,73 @@
+"""Utility functions for common UI components."""
+
+from typing import Optional, Callable
+
+from PySide6.QtCore import Qt, QSize
+from PySide6.QtGui import QIcon, QAction
+from PySide6.QtWidgets import QWidget, QToolButton
+
+
+def make_tool_button(
+    parent: QWidget,
+    icon: Optional[QIcon] = None,
+    tooltip: str = "",
+    callback: Optional[Callable[[], None]] = None,
+    checkable: bool = False,
+    action: Optional[QAction] = None,
+    icon_size: int = 32,
+    button_size: Optional[int] = None,
+) -> QToolButton:
+    """Create a standardized ``QToolButton`` for overlay toolbars.
+
+    This helper centralizes the common configuration for tool buttons used
+    across the different overlays. It supports both simple icon/callback
+    buttons as well as buttons bound to a ``QAction``.
+
+    Parameters
+    ----------
+    parent:
+        Widget that will parent the created button.
+    icon:
+        Optional ``QIcon`` displayed on the button. Ignored if ``action`` is
+        provided.
+    tooltip:
+        Text shown when the user hovers the button.
+    callback:
+        Function invoked when the button is clicked. Ignored if ``action`` is
+        provided.
+    checkable:
+        Whether the button maintains an on/off state.
+    action:
+        Optional ``QAction`` associated with the button instead of a direct
+        callback.
+    icon_size:
+        Size of the icon in pixels.
+    button_size:
+        Size of the square button. If ``None``, it defaults to
+        ``max(28, icon_size + 4)``.
+
+    Returns
+    -------
+    QToolButton
+        The configured tool button ready to be added to a layout.
+    """
+
+    btn = QToolButton(parent)
+    if action:
+        btn.setDefaultAction(action)
+    elif icon:
+        btn.setIcon(icon)
+        if callback:
+            btn.clicked.connect(callback)
+    elif callback:
+        btn.clicked.connect(callback)
+
+    if tooltip:
+        btn.setToolTip(tooltip)
+    btn.setIconSize(QSize(icon_size, icon_size))
+    btn.setCheckable(checkable)
+    size = max(28, icon_size + 4) if button_size is None else button_size
+    btn.setFixedSize(size, size)
+    btn.setToolButtonStyle(Qt.ToolButtonIconOnly)
+    btn.setAutoRaise(True)
+    return btn

--- a/ui/zoomable_view.py
+++ b/ui/zoomable_view.py
@@ -20,72 +20,7 @@ from ui.icons import (
     icon_open_menu, icon_close_menu, icon_close_menu_inv
 )
 from ui.library.library_widget import LIB_MIME
-
-
-def make_tool_button(
-    parent: QWidget,
-    icon: Optional[QIcon] = None,
-    tooltip: str = "",
-    callback: Optional[Callable[[], None]] = None,
-    checkable: bool = False,
-    action: Optional[QAction] = None,
-    icon_size: int = 32,
-    button_size: Optional[int] = None,
-) -> QToolButton:
-    """Create a standardized ``QToolButton`` for overlay toolbars.
-
-    This helper centralizes the common configuration for tool buttons used
-    across the different overlays. It supports both simple icon/callback
-    buttons as well as buttons bound to a ``QAction``.
-
-    Parameters
-    ----------
-    parent:
-        Widget that will parent the created button.
-    icon:
-        Optional ``QIcon`` displayed on the button. Ignored if ``action`` is
-        provided.
-    tooltip:
-        Text shown when the user hovers the button.
-    callback:
-        Function invoked when the button is clicked. Ignored if ``action`` is
-        provided.
-    checkable:
-        Whether the button maintains an on/off state.
-    action:
-        Optional ``QAction`` associated with the button instead of a direct
-        callback.
-    icon_size:
-        Size of the icon in pixels.
-    button_size:
-        Size of the square button. If ``None``, it defaults to
-        ``max(28, icon_size + 4)``.
-
-    Returns
-    -------
-    QToolButton
-        The configured tool button ready to be added to a layout.
-    """
-
-    btn = QToolButton(parent)
-    if action:
-        btn.setDefaultAction(action)
-    elif icon:
-        btn.setIcon(icon)
-        if callback:
-            btn.clicked.connect(callback)
-    elif callback:
-        btn.clicked.connect(callback)
-
-    if tooltip:
-        btn.setToolTip(tooltip)
-    btn.setIconSize(QSize(icon_size, icon_size))
-    btn.setCheckable(checkable)
-    size = max(28, icon_size + 4) if button_size is None else button_size
-    btn.setFixedSize(size, size)
-    btn.setToolButtonStyle(Qt.ToolButtonIconOnly)
-    btn.setAutoRaise(True)
-    return btn
+from ui.utils import make_tool_button
 
 
 class ZoomableView(QGraphicsView):


### PR DESCRIPTION
## Summary
- move `make_tool_button` into new `ui.utils` module
- import shared helper in `zoomable_view`
- add unit test for `make_tool_button` and provide Qt test fixture

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f69c75998832bbaffa72f2d4eda4b