### PR TITLE
Refactor timeline dock into helper

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -142,6 +142,8 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
 
 - Refactor Puppet : `PuppetMember` converti en `dataclass` et `compute_child_map` utilise désormais `defaultdict` pour
   construire le mapping parent → enfants plus simplement.
+- Refactor Dock Timeline : création de `ui/docks.setup_timeline_dock` et délégation depuis `MainWindow` pour factoriser la
+  configuration du dock de timeline.
 
 ## État actuel et prochaines étapes possibles
 

--- a/ui/docks.py
+++ b/ui/docks.py
@@ -1,0 +1,25 @@
+"""Dock setup utilities."""
+
+from __future__ import annotations
+
+import logging
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDockWidget, QMainWindow, QWidget as _QW
+
+from ui.timeline_widget import TimelineWidget
+
+
+def setup_timeline_dock(main_window: QMainWindow) -> TimelineWidget:
+    """Create the timeline dock on ``main_window`` and return the widget."""
+    timeline_dock: QDockWidget = QDockWidget("", main_window)
+    timeline_dock.setObjectName("dock_timeline")
+    timeline_widget: TimelineWidget = TimelineWidget()
+    timeline_dock.setWidget(timeline_widget)
+    timeline_dock.setFeatures(QDockWidget.DockWidgetClosable)
+    try:
+        timeline_dock.setTitleBarWidget(_QW())
+    except (ImportError, RuntimeError) as e:
+        logging.debug("Custom title bar not set on dock: %s", e)
+    main_window.timeline_dock = timeline_dock
+    main_window.addDockWidget(Qt.BottomDockWidgetArea, timeline_dock)
+    return timeline_widget

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -10,10 +10,8 @@ from PySide6.QtWidgets import (
     QGraphicsScene,
     QVBoxLayout,
     QWidget,
-    QDockWidget,
     QFrame,
     QMessageBox,
-    QWidget as _QW,
 )
 
 from ui.scene import scene_io, actions as scene_actions
@@ -28,6 +26,7 @@ from ui.scene.scene_controller import SceneController
 from ui.scene.scene_visuals import SceneVisuals
 from ui.settings_manager import SettingsManager
 from ui.timeline_widget import TimelineWidget
+from ui.docks import setup_timeline_dock
 from ui.zoomable_view import ZoomableView
 from ui.library import actions as library_actions
 from ui.inspector import actions as inspector_actions
@@ -46,7 +45,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Borne and the Bayrou - Disco MIX")
         self._setup_scene()
         self._setup_overlays()
-        self._setup_timeline_dock()
+        self.timeline_widget: TimelineWidget = setup_timeline_dock(self)
         self._setup_playback()
         self._setup_actions()
         self._setup_tool_overlays()
@@ -88,19 +87,6 @@ class MainWindow(QMainWindow):
         self.overlays = OverlayManager(self)
         self.overlays.build_overlays()
         self.onion: OnionSkinManager = OnionSkinManager(self)
-
-    def _setup_timeline_dock(self) -> None:
-        """Creates and configures the timeline dock widget."""
-        self.timeline_dock: QDockWidget = QDockWidget("", self)
-        self.timeline_dock.setObjectName("dock_timeline")
-        self.timeline_widget: TimelineWidget = TimelineWidget()
-        self.timeline_dock.setWidget(self.timeline_widget)
-        self.timeline_dock.setFeatures(QDockWidget.DockWidgetClosable)
-        try:
-            self.timeline_dock.setTitleBarWidget(_QW())
-        except (ImportError, RuntimeError) as e:
-            logging.debug("Custom title bar not set on dock: %s", e)
-        self.addDockWidget(Qt.BottomDockWidgetArea, self.timeline_dock)
 
     def _setup_playback(self) -> None:
         """Initializes the playback controller."""


### PR DESCRIPTION
## Summary
- factor timeline dock setup into new `ui.docks` helper
- use the helper in `MainWindow` instead of private method
- document the dock refactor in STATE_OF_THE_ART.md

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f75901584832bacad6a0c5d1c61a3