### PR TITLE
Centralize scene JSON validation

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -152,6 +152,10 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
   assurant l'échange d'icône, la visibilité des boutons et la conservation de la
   position latérale des panneaux.
 
+- Validation JSON centralisée : extraction des règles de `_validate_data`
+  vers `core/scene_validation.py` avec des fonctions dédiées
+  (`validate_settings`, `validate_objects`, `validate_keyframes`) et tests unitaires.
+
 ## État actuel et prochaines étapes possibles
 
 L'application a évolué d'un simple outil d'animation de marionnette à un **logiciel de composition de scène 2D fonctionnel et robuste**. L'interface a été professionnalisée et la gestion de plusieurs objets est désormais possible.

--- a/core/scene_model.py
+++ b/core/scene_model.py
@@ -8,6 +8,11 @@ import logging
 import json
 from dataclasses import dataclass, field, asdict
 from core.puppet_model import Puppet
+from core.scene_validation import (
+    validate_settings,
+    validate_objects,
+    validate_keyframes,
+)
 
 
 @dataclass
@@ -182,31 +187,14 @@ class SceneModel:
         - keyframes (if present) must be a list of dict with an integer 'index'
         """
         if not isinstance(data, dict):
+            logging.error("root: expected dict, got %s", type(data).__name__)
             return False
-        settings = data.get("settings", {})
-        if settings is not None and not isinstance(settings, dict):
+        if not validate_settings(data.get("settings")):
             return False
-        if isinstance(settings, dict):
-            for k in ("start_frame", "end_frame", "fps", "scene_width", "scene_height"):
-                if k in settings and not isinstance(settings[k], int):
-                    return False
-        objects = data.get("objects", {})
-        if objects is not None and not isinstance(objects, dict):
+        if not validate_objects(data.get("objects")):
             return False
-        if isinstance(objects, dict):
-            for k, v in objects.items():
-                if not isinstance(k, str) or not isinstance(v, dict):
-                    return False
-        keyframes = data.get("keyframes", [])
-        if keyframes is not None and not isinstance(keyframes, list):
+        if not validate_keyframes(data.get("keyframes")):
             return False
-        if isinstance(keyframes, list):
-            for kf in keyframes:
-                if not isinstance(kf, dict):
-                    return False
-                idx = kf.get("index")
-                if idx is not None and not isinstance(idx, int):
-                    return False
         return True
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the whole scene into a JSON-friendly dictionary."""

--- a/core/scene_validation.py
+++ b/core/scene_validation.py
@@ -1,0 +1,66 @@
+"""Validation helpers for scene import/export structures."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+def validate_settings(data: Any) -> bool:
+    """Validate scene settings structure.
+
+    ``data`` should be a mapping of setting keys to integer values. Unknown keys
+    are ignored. ``None`` is accepted and treated as valid to allow optional
+    sections in the JSON.
+    """
+    if data is None:
+        return True
+    if not isinstance(data, dict):
+        logging.error("settings: expected dict, got %s", type(data).__name__)
+        return False
+    for key in ("start_frame", "end_frame", "fps", "scene_width", "scene_height"):
+        if key in data and not isinstance(data[key], int):
+            logging.error("settings: %s must be int", key)
+            return False
+    return True
+
+
+def validate_objects(data: Any) -> bool:
+    """Validate objects mapping structure.
+
+    ``data`` should map object names (strings) to dictionaries describing their
+    state. ``None`` is accepted as a valid value meaning no objects.
+    """
+    if data is None:
+        return True
+    if not isinstance(data, dict):
+        logging.error(
+            "objects: expected dict mapping str -> dict, got %s", type(data).__name__
+        )
+        return False
+    for name, obj in data.items():
+        if not isinstance(name, str) or not isinstance(obj, dict):
+            logging.error("objects: invalid entry %r -> %r", name, obj)
+            return False
+    return True
+
+
+def validate_keyframes(data: Any) -> bool:
+    """Validate keyframes list structure.
+
+    ``data`` should be a list of dictionaries, each containing an optional
+    integer ``index``.
+    """
+    if data is None:
+        return True
+    if not isinstance(data, list):
+        logging.error("keyframes: expected list, got %s", type(data).__name__)
+        return False
+    for kf in data:
+        if not isinstance(kf, dict):
+            logging.error("keyframes: each item must be dict, got %r", kf)
+            return False
+        idx = kf.get("index")
+        if idx is not None and not isinstance(idx, int):
+            logging.error("keyframes: 'index' must be int, got %r", idx)
+            return False
+    return True

--- a/tests/test_scene_validation.py
+++ b/tests/test_scene_validation.py
@@ -1,0 +1,33 @@
+"""Tests for scene validation helpers."""
+
+import logging
+
+from core.scene_validation import (
+    validate_settings,
+    validate_objects,
+    validate_keyframes,
+)
+
+
+def test_validate_settings(caplog):
+    """Settings must be dict with integer values."""
+    assert validate_settings({"fps": 24, "scene_width": 800}) is True
+    with caplog.at_level(logging.ERROR):
+        assert validate_settings({"fps": "fast"}) is False
+        assert "fps" in caplog.text
+
+
+def test_validate_objects(caplog):
+    """Objects must map names to dicts."""
+    assert validate_objects({"tree": {}}) is True
+    with caplog.at_level(logging.ERROR):
+        assert validate_objects({"tree": []}) is False
+        assert "invalid entry" in caplog.text
+
+
+def test_validate_keyframes(caplog):
+    """Keyframes must be list of dict with integer index."""
+    assert validate_keyframes([{"index": 1}]) is True
+    with caplog.at_level(logging.ERROR):
+        assert validate_keyframes([{"index": "a"}]) is False
+        assert "index" in caplog.text


### PR DESCRIPTION
## Summary
- factor scene data checks into `core.scene_validation` with dedicated functions
- simplify `SceneModel._validate_data` by delegating to helpers
- cover each helper with focused unit tests and document the change

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689faac46354832bb34152936653d8c9