### PR TITLE
Add CI workflow with lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Lint
+        run: pylint $(git ls-files '*.py')
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
    ** 🤑 Le MACRON‑O‑TRON 3000 🤑 **
 </h1>
 
+[![CI](https://github.com/OWNER/BaBv2/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/BaBv2/actions/workflows/ci.yml)
+
 
 ![apercu](https://github.com/user-attachments/assets/243fd05d-de03-4068-abe9-b780baf8999f)
 

--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -80,6 +80,8 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
 
 ## Mises à jour récentes
 
+- Mise en place d'une intégration continue via GitHub Actions exécutant l'installation des dépendances, pylint et pytest.
+
 - Externalisation de la configuration des marionnettes : hiérarchie, pivots et z-order sont désormais définis dans `core/puppet_config.json` et chargés dynamiquement par `Puppet`.
 - Correction du chargement JSON: `SceneModel.import_json` peuple désormais correctement le modèle via `from_dict` et retourne un booléen de succès.
 - Nettoyage: suppression de code inatteignable dans `SceneModel.import_json` et sécurisation de `ui/object_item.py` pour éviter une référence potentiellement non définie dans les logs.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running dependency installation, pylint, and pytest
- surface build status badge in README
- document CI setup in state-of-the-art

## Testing
- `pip install -r requirements.txt`
- `pylint $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc132e578832b9e0454d8e3ebd927