### PR TITLE
Add docstrings to validation helpers and overlay widgets

### DIFF
--- a/STATE_OF_THE_ART.md
+++ b/STATE_OF_THE_ART.md
@@ -114,6 +114,8 @@ L'application est construite en Python avec la bibliothèque d'interface graphiq
   - `ui/inspector_widget.py`: docstrings classe/méthodes et types pour callbacks.
   - `ui/library_widget.py`: docstring de module/classe et annotation `reload()`.
   - `ui/timeline_widget.py`: docstring de classe pour préciser le rôle et les signaux exposés.
+  - `core/scene_validation.py`: docstring de module décrivant les vérifications JSON.
+  - `ui/draggable_widget.py`: docstrings pour les widgets d'overlays et leurs méthodes.
 - Suppression temporelle des objets: la logique d'affichage considère désormais le dernier keyframe ≤ frame courante comme point de vérité. Si ce keyframe ne référence pas un objet, celui-ci est masqué à partir de cette frame (et jusqu'à ce qu'un nouveau keyframe le réintroduise). L’inspecteur se synchronise sur cette règle.
 - Nettoyage historique: retrait des vestiges `grid` / `snap_to_grid` dans `PuppetPiece` (non utilisés), sans impact sur le comportement actuel.
 - (Revert) Affichage unifié des membres retiré: l'approche basée sur `shape()` des SVG produit des bboxes rectangulaires non conformes. À revisiter ultérieurement avec une extraction de silhouette par rendu offscreen si nécessaire.

--- a/core/scene_validation.py
+++ b/core/scene_validation.py
@@ -1,4 +1,11 @@
-"""Validation helpers for scene import/export structures."""
+"""Validation helpers for scene JSON data.
+
+This module provides light-weight checks used when importing a scene from
+JSON. Each function validates part of the structure (global settings,
+objects map or keyframes list) and logs descriptive errors when values do not
+match the expected types.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- document JSON validation helpers
- add comprehensive docstrings to draggable overlay widgets
- record docstring additions in STATE_OF_THE_ART

## Testing
- `pydocstyle --select=D100,D101,D102,D103,D104,D105,D106,D107`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fe824eb3c832b9a908c8d4113ae10