### PR TITLE
ui: centralise preferences in JSON profile

### DIFF
--- a/macronotron.py
+++ b/macronotron.py
@@ -1,24 +1,28 @@
 """Main entry point for the Macronotron application."""
 
 import sys
+from pathlib import Path
 from typing import List
 
 from PySide6.QtWidgets import QApplication
 from ui.main_window import MainWindow
 from ui.styles import apply_stylesheet
+from ui.ui_profile import UIProfile
 
 
-def create_app(argv: List[str]) -> QApplication:
+def create_app(argv: List[str]) -> tuple[QApplication, UIProfile]:
     """Crée (ou récupère) l'instance QApplication et applique le thème."""
     app = QApplication.instance() or QApplication(argv)
-    apply_stylesheet(app)
-    return app
+    profile_path = Path("ui_profile.json")
+    profile = UIProfile.import_json(str(profile_path))
+    apply_stylesheet(app, profile)
+    return app, profile
 
 
 def main(argv: List[str]) -> int:
     """Point d'entrée principal de l'application. Retourne un code de sortie."""
-    app = create_app(argv)
-    macronotron = MainWindow()
+    app, profile = create_app(argv)
+    macronotron = MainWindow(profile)
     macronotron.show()
     return app.exec()
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -25,6 +25,7 @@ from ui.playback_controller import PlaybackController
 from ui.scene import SceneController
 from ui.scene.scene_visuals import SceneVisuals
 from ui.settings_manager import SettingsManager
+from ui.ui_profile import UIProfile
 from ui.docks import setup_timeline_dock
 from ui.zoomable_view import ZoomableView
 from ui.library import actions as library_actions
@@ -34,15 +35,14 @@ from ui.inspector import actions as inspector_actions
 class MainWindow(QMainWindow):
     """Main application window.
 
-    This class orchestrates all UI components, including the scene, timeline,
-    inspector, and library. It holds the central `SceneModel` and manages
-    interactions between different parts of the UI.
+    Orchestrates UI components et conserve un ``UIProfile`` centralisé.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, profile: UIProfile | None = None) -> None:
         """Initialize the main window, scene, and all UI components."""
         super().__init__()
         self.setWindowTitle("Borne and the Bayrou - Disco MIX")
+        self.profile: UIProfile = profile or UIProfile.import_json("ui_profile.json")
 
         # Core components (model, scene, object manager) must exist before
         # any other setup step.  They are grouped into a dedicated function so
@@ -155,7 +155,7 @@ class MainWindow(QMainWindow):
 
     def _setup_settings(self) -> None:
         """Initializes the settings manager and loads settings."""
-        self.settings = SettingsManager(self)
+        self.settings = SettingsManager(self, self.profile)
         self.load_settings()
 
     def _apply_startup_preferences(self) -> None:


### PR DESCRIPTION
## Summary
- use `UIProfile` JSON store to persist window and overlay geometries
- drive theming via profile and inject into main window and settings manager
- load profile at startup and apply stylesheet accordingly

## Testing
- `pytest -q`
- `pylint core ui macronotron.py -rn | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68a2bdbb5dfc832b9a2d28816efec626