### PR TITLE
refactor: introduce app controller

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -1,0 +1,104 @@
+"""Application controller orchestrating the MainWindow and SceneModel."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from core.scene_model import Keyframe
+from ui import selection_sync
+from ui.scene import scene_io
+
+
+class AppController:
+    """Centralise la logique métier autour de la `MainWindow`."""
+
+    def __init__(self, win: Any) -> None:
+        self.win = win
+        self._install_shortcuts()
+
+    # --- Initialisation -------------------------------------------------
+    def startup_sequence(self) -> None:
+        """Lance la séquence de démarrage de l'interface."""
+        self.win.showMaximized()
+        self.win.timeline_dock.show()
+        self.win.timeline_dock.visibilityChanged.connect(lambda _: self.win.ensure_fit())
+        self.win.timeline_dock.topLevelChanged.connect(lambda _: self.win.ensure_fit())
+        self.win.ensure_fit()
+        scene_io.create_blank_scene(self.win)
+        self.win.ensure_fit()
+        self.win.scene.selectionChanged.connect(self.on_scene_selection_changed)
+
+    # --- Raccourcis globaux --------------------------------------------
+    def _install_shortcuts(self) -> None:
+        """Connecte les raccourcis de copie/collage de pose."""
+        try:
+            self.win._kf_copy_sc.activated.connect(self.copy_current_keyframe)
+            self.win._kf_paste_sc.activated.connect(self.paste_current_keyframe)
+        except Exception:  # pylint: disable=broad-except
+            logging.exception("Failed to install keyframe shortcuts")
+
+    def copy_current_keyframe(self) -> None:
+        """Copie le keyframe courant via le `PlaybackController`."""
+        try:
+            idx = int(self.win.scene_model.current_frame)
+            if idx in getattr(self.win.timeline_widget, "_kfs", set()):
+                self.win.playback_handler.copy_keyframe(idx)  # type: ignore[attr-defined]
+        except Exception:  # pylint: disable=broad-except
+            logging.debug("Copy current keyframe shortcut failed")
+
+    def paste_current_keyframe(self) -> None:
+        """Colle le keyframe courant via le `PlaybackController`."""
+        try:
+            idx = int(self.win.scene_model.current_frame)
+            self.win.playback_handler.paste_keyframe(idx)  # type: ignore[attr-defined]
+        except Exception:  # pylint: disable=broad-except
+            logging.debug("Paste current keyframe shortcut failed")
+
+    # --- Manipulation de keyframes ------------------------------------
+    def add_keyframe(self, frame_index: int) -> None:
+        """Ajoute un keyframe en capturant l'état courant de la scène."""
+        state = self.win.object_manager.capture_scene_state()
+        self.win.scene_model.add_keyframe(frame_index, state)
+        self.win.timeline_widget.add_keyframe_marker(frame_index)
+
+    def update_scene_from_model(self) -> None:
+        """Applique l'état du modèle à la scène graphique."""
+        index: int = self.win.scene_model.current_frame
+        keyframes: Dict[int, Keyframe] = self.win.scene_model.keyframes
+        if not keyframes:
+            return
+        graphics_items: Dict[str, Any] = self.win.object_manager.graphics_items
+        logging.debug(
+            "update_scene_from_model: frame=%s, keyframes=%s",
+            index,
+            list(keyframes.keys()),
+        )
+        self._apply_puppet_states(graphics_items, keyframes, index)
+        self._apply_object_states(graphics_items, keyframes, index)
+
+    def _apply_puppet_states(
+        self, graphics_items: Dict[str, Any], keyframes: Dict[int, Keyframe], index: int
+    ) -> None:
+        """Applique les états des pantins."""
+        self.win.scene_controller.apply_puppet_states(graphics_items, keyframes, index)
+
+    def _apply_object_states(
+        self, graphics_items: Dict[str, Any], keyframes: Dict[int, Keyframe], index: int
+    ) -> None:
+        """Applique les états des objets."""
+        self.win.scene_controller.apply_object_states(graphics_items, keyframes, index)
+
+    # --- Synchronisation scène/inspecteur ------------------------------
+    def select_object_in_inspector(self, name: str) -> None:
+        """Sélectionne un objet dans l'inspecteur."""
+        selection_sync.select_object_in_inspector(self.win, name)
+
+    def on_scene_selection_changed(self) -> None:
+        """Réagit aux changements de sélection dans la scène."""
+        selection_sync.scene_selection_changed(self.win)
+
+    def on_frame_update(self) -> None:
+        """Met à jour la scène après un changement de frame."""
+        self.update_scene_from_model()
+        self.win.update_onion_skins()

--- a/tests/test_object_keyframe_states.py
+++ b/tests/test_object_keyframe_states.py
@@ -41,7 +41,7 @@ def test_object_state_is_per_keyframe(_app):
 
     # Move free object to a scene position and snapshot on KF 0
     item.setPos(123.0, 234.0)
-    win.add_keyframe(0)
+    win.controller.add_keyframe(0)
     win.object_manager.snapshot_current_frame()
 
     # Attach the object at KF 0 and set a local offset, re-snapshot
@@ -51,7 +51,7 @@ def test_object_state_is_per_keyframe(_app):
 
     # Jump to frame 10, detach and set a different scene position, snapshot
     win.playback_handler.go_to_frame(10)
-    win.add_keyframe(10)
+    win.controller.add_keyframe(10)
     win.scene_controller.detach_object(name)
     item = win.object_manager.graphics_items[name]
     assert item.parentItem() is None
@@ -78,7 +78,7 @@ def test_object_state_is_per_keyframe(_app):
 
     # Now, ensure that applying states restores correct parent/positions
     win.playback_handler.go_to_frame(0)
-    win.update_scene_from_model()
+    win.controller.update_scene_from_model()
     item0 = win.object_manager.graphics_items[name]
     assert isinstance(item0.parentItem(), QGraphicsItem)
     # Parent is the puppet piece for manu:main_droite
@@ -88,7 +88,7 @@ def test_object_state_is_per_keyframe(_app):
     assert item0.y() == pytest.approx(20.0)
 
     win.playback_handler.go_to_frame(10)
-    win.update_scene_from_model()
+    win.controller.update_scene_from_model()
     item10 = win.object_manager.graphics_items[name]
     assert item10.parentItem() is None
     assert item10.x() == pytest.approx(345.0)

--- a/ui/actions.py
+++ b/ui/actions.py
@@ -132,8 +132,10 @@ def connect_signals(win: Any) -> None:
     win.playback_handler.snapshot_requested.connect(
         win.object_manager.snapshot_current_frame
     )
-    win.playback_handler.frame_update_requested.connect(win._on_frame_update)
-    win.playback_handler.keyframe_add_requested.connect(win.add_keyframe)
+    win.playback_handler.frame_update_requested.connect(
+        win.controller.on_frame_update
+    )
+    win.playback_handler.keyframe_add_requested.connect(win.controller.add_keyframe)
 
     # Library signals
     win.library_widget.addRequested.connect(

--- a/ui/object_item.py
+++ b/ui/object_item.py
@@ -62,7 +62,7 @@ class _ObjectItemMixin:
                             kf.objects[name] = obj.to_dict()
                     # Sync selection with inspector
                     if change == QGraphicsItem.ItemSelectedHasChanged and bool(value):
-                        mw.select_object_in_inspector(name)
+                        mw.controller.select_object_in_inspector(name)
             except RuntimeError as e:
                 logging.error(f"Error in itemChange for {name}: {e}")
         return super().itemChange(change, value)

--- a/ui/scene/object_ops.py
+++ b/ui/scene/object_ops.py
@@ -193,7 +193,7 @@ class ObjectOps:
             )
         cur_idx = self.win.scene_model.current_frame
         if cur_idx not in self.win.scene_model.keyframes:
-            self.win.add_keyframe(cur_idx)
+            self.win.controller.add_keyframe(cur_idx)
         kf: Optional[Keyframe] = self.win.scene_model.keyframes.get(cur_idx)
         if kf is not None:
             kf.objects[obj_name] = obj.to_dict()
@@ -283,7 +283,7 @@ class ObjectOps:
             )
         cur_idx = self.win.scene_model.current_frame
         if cur_idx not in self.win.scene_model.keyframes:
-            self.win.add_keyframe(cur_idx)
+            self.win.controller.add_keyframe(cur_idx)
         kf: Optional[Keyframe] = self.win.scene_model.keyframes.get(cur_idx)
         if kf is not None:
             kf.objects[obj_name] = obj.to_dict()
@@ -340,7 +340,7 @@ class ObjectOps:
         self._add_object_graphics(obj)
         cur: int = self.win.scene_model.current_frame
         if cur not in self.win.scene_model.keyframes:
-            self.win.add_keyframe(cur)
+            self.win.controller.add_keyframe(cur)
         kf: Optional[Keyframe] = self.win.scene_model.keyframes.get(cur)
         gi: Optional[QGraphicsItem] = self.win.object_manager.graphics_items.get(name)
         if kf is not None and gi is not None:
@@ -401,7 +401,7 @@ class ObjectOps:
         self._add_object_graphics(obj)
         cur: int = self.win.scene_model.current_frame
         if cur not in self.win.scene_model.keyframes:
-            self.win.add_keyframe(cur)
+            self.win.controller.add_keyframe(cur)
         kf: Optional[Keyframe] = self.win.scene_model.keyframes.get(cur)
         if kf is not None:
             kf.objects[name] = obj.to_dict()
@@ -417,7 +417,7 @@ class ObjectOps:
         """
         cur: int = self.win.scene_model.current_frame
         if cur not in self.win.scene_model.keyframes:
-            self.win.add_keyframe(cur)
+            self.win.controller.add_keyframe(cur)
         for fr, kf in list(self.win.scene_model.keyframes.items()):
             if fr >= cur and name in kf.objects:
                 del kf.objects[name]

--- a/ui/scene/scene_controller.py
+++ b/ui/scene/scene_controller.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional, Protocol, cast
+from typing import TYPE_CHECKING, Any, Optional, Protocol, cast
 
 from PySide6.QtCore import QPointF
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsScene
@@ -39,8 +39,7 @@ class MainWindowProtocol(Protocol):
     _suspend_item_updates: bool
     inspector_widget: InspectorWidgetProtocol
 
-    def add_keyframe(self, index: int) -> None:
-        """Insert a keyframe at the given timeline index."""
+    controller: Any
 
     def _update_background(self) -> None: ...
 
@@ -126,7 +125,7 @@ class SceneController:
         try:
             # Snapshot current state if the frame has no keyframe yet
             if cur not in self.win.scene_model.keyframes:
-                self.win.add_keyframe(cur)
+                self.win.controller.add_keyframe(cur)
         except Exception:  # pylint: disable=broad-except
             # Fallback: attempt to create an empty keyframe if UI path fails
             self.win.scene_model.add_keyframe(
@@ -147,7 +146,7 @@ class SceneController:
         vmap[str(slot)] = str(variant_name)
         # Re-apply scene from model to keep everything in sync (onion, etc.)
         try:
-            self.win.update_scene_from_model()
+            self.win.controller.update_scene_from_model()
             self.win.update_onion_skins()
         except (RuntimeError, AttributeError):
             logging.exception("Failed to refresh scene after variant change")

--- a/ui/scene/scene_io.py
+++ b/ui/scene/scene_io.py
@@ -41,7 +41,7 @@ def load_scene(win: "MainWindow") -> None:
 def export_scene(win: "MainWindow", file_path: str) -> None:
     """Exports the current scene state to a JSON file."""
     if not win.scene_model.keyframes:
-        win.add_keyframe(0)
+        win.controller.add_keyframe(0)
     # Capture latest on-screen state into the current keyframe if it exists
     cur = win.scene_model.current_frame
     if cur in win.scene_model.keyframes:
@@ -146,14 +146,14 @@ def import_scene(win: MainWindow, file_path: str) -> None:
         win.inspector_widget.refresh()
 
         # Assure une application d'état même si la frame n'a pas changé (ex: start=0, current=0)
-        win.update_scene_from_model()
+        win.controller.update_scene_from_model()
         QTimer.singleShot(
             0,
             lambda: (
                 win.timeline_widget.set_current_frame(
                     win.scene_model.current_frame or win.scene_model.start_frame
                 ),
-                win.update_scene_from_model(),
+                win.controller.update_scene_from_model(),
             ),
         )
 


### PR DESCRIPTION
## Résumé
- déplacer la logique d'orchestration dans `AppController`
- déléguer les opérations métier de `MainWindow` vers `AppController`
- mettre à jour les signaux/slots et les tests pour utiliser le contrôleur

## Tests
- `pytest -q`
- `pylint core ui controllers macronotron.py`


------
https://chatgpt.com/codex/tasks/task_e_68a31eec4d48832bbfd8321fbecf957a