### PR TITLE
scene: introduire service et vue dédiés

### DIFF
--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -2,5 +2,6 @@
 
 from .app_controller import AppController
 from .object_controller import ObjectController
+from .scene_service import SceneService
 
-__all__ = ["AppController", "ObjectController"]
+__all__ = ["AppController", "ObjectController", "SceneService"]

--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -58,8 +58,7 @@ class AppController:
     # --- Manipulation de keyframes ------------------------------------
     def add_keyframe(self, frame_index: int) -> None:
         """Ajoute un keyframe en capturant l'état courant de la scène."""
-        state = self.win.object_controller.capture_scene_state()
-        self.win.scene_model.add_keyframe(frame_index, state)
+        self.win.scene_controller.service.add_keyframe(frame_index)
         self.win.timeline_widget.add_keyframe_marker(frame_index)
 
     def update_scene_from_model(self) -> None:

--- a/controllers/scene_service.py
+++ b/controllers/scene_service.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Service centralisant les opérations sur le ``SceneModel``.
+
+Ce module encapsule la manipulation du modèle de scène : gestion des pantins,
+variants et keyframes. Il reste agnostique de toute interaction Qt; les vues
+s'abonnent à ses signaux pour réagir aux changements.
+"""
+
+from typing import Callable, Dict, Any, Optional
+
+from PySide6.QtCore import QObject, Signal
+
+from core.scene_model import SceneModel, Keyframe
+
+
+class SceneService(QObject):
+    """Fournit une API de haut niveau pour modifier la scène."""
+
+    background_changed = Signal(object)
+    scene_resized = Signal(int, int)
+
+    def __init__(
+        self,
+        model: SceneModel,
+        state_provider: Callable[[], Dict[str, Dict[str, Any]]],
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self._state_provider = state_provider
+
+    # ------------------------------------------------------------------
+    # Keyframes
+    def add_keyframe(self, frame_index: int) -> None:
+        """Capture l'état courant et ajoute un keyframe."""
+        state = self._state_provider()
+        self.model.add_keyframe(frame_index, state)
+
+    # ------------------------------------------------------------------
+    # Pantins
+    def add_puppet(self, name: str, puppet: Any) -> None:
+        """Ajoute un pantin au modèle."""
+        self.model.add_puppet(name, puppet)
+
+    def remove_puppet(self, name: str) -> None:
+        """Retire un pantin du modèle."""
+        self.model.remove_puppet(name)
+
+    def set_member_variant(
+        self, puppet_name: str, slot: str, variant_name: str
+    ) -> None:
+        """Enregistre la variante choisie pour un slot de pantin."""
+        cur = int(self.model.current_frame)
+        if cur not in self.model.keyframes:
+            self.add_keyframe(cur)
+        kf: Optional[Keyframe] = self.model.keyframes.get(cur)
+        if kf is None:
+            return
+        pup_map = kf.puppets.setdefault(puppet_name, {})
+        vmap = pup_map.setdefault("_variants", {})
+        vmap[str(slot)] = str(variant_name)
+
+    # ------------------------------------------------------------------
+    # Scène
+    def set_background_path(self, path: Optional[str]) -> None:
+        """Définit le chemin d'arrière-plan puis émet un signal."""
+        self.model.background_path = path
+        self.background_changed.emit(path)
+
+    def set_scene_size(self, width: int, height: int) -> None:
+        """Met à jour les dimensions de la scène et notifie les vues."""
+        self.model.scene_width = int(width)
+        self.model.scene_height = int(height)
+        self.scene_resized.emit(int(width), int(height))

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -22,7 +22,7 @@ from controllers.object_controller import ObjectController
 from ui.onion_skin import OnionSkinManager
 from ui.overlay_manager import OverlayManager
 from ui.playback_controller import PlaybackController
-from ui.scene import SceneController
+from ui.scene import SceneController, SceneView
 from ui.scene.scene_visuals import SceneVisuals
 from ui.settings_manager import SettingsManager
 from ui.docks import setup_timeline_dock
@@ -139,8 +139,9 @@ class MainWindow(QMainWindow):
 
     def _setup_scene_controller(self) -> None:
         """Creates the scene controller facade."""
+        view = SceneView(self, self.visuals)
         self.scene_controller: SceneController = SceneController(
-            self, visuals=self.visuals, onion=self.onion
+            self, view=view, onion=self.onion
         )
 
     def _connect_actions(self) -> None:

--- a/ui/scene/__init__.py
+++ b/ui/scene/__init__.py
@@ -3,10 +3,12 @@
 from .scene_controller import SceneController
 from .puppet_ops import PuppetOps
 from .library_ops import LibraryOps, LibraryPayload
+from .scene_view import SceneView
 
 __all__ = [
     "SceneController",
     "PuppetOps",
     "LibraryOps",
     "LibraryPayload",
+    "SceneView",
 ]

--- a/ui/scene/library_ops.py
+++ b/ui/scene/library_ops.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .scene_controller import MainWindowProtocol
     from .puppet_ops import PuppetOps
     from controllers.object_controller import ObjectController
-    from typing import Callable
+    from controllers.scene_service import SceneService
 
 
 class LibraryPayload(TypedDict, total=False):
@@ -30,13 +30,13 @@ class LibraryOps:
         win: MainWindowProtocol,
         puppet_ops: PuppetOps,
         object_ctrl: ObjectController,
-        set_background_path: "Callable[[Optional[str]], None]",
+        scene_service: SceneService,
     ) -> None:
         """Initialize helpers to route library items into the scene."""
         self.win = win
         self.puppets = puppet_ops
         self.objects = object_ctrl
-        self.set_background_path = set_background_path
+        self.scene_service = scene_service
 
     def add_library_item_to_scene(self, payload: LibraryPayload) -> None:
         """Adds a library item to the scene."""
@@ -57,12 +57,7 @@ class LibraryOps:
             return
 
         if kind == "background":
-            try:
-                self.set_background_path(path)
-            except (OSError, RuntimeError):
-                logging.exception("Failed to set background path")
-                self.win.scene_model.background_path = path
-                self.win._update_background()
+            self.scene_service.set_background_path(path)
         elif kind == "object":
             self.objects.create_object_from_file(path, scene_pos)
         elif kind == "puppet":
@@ -72,7 +67,9 @@ class LibraryOps:
             if scene_pos is not None:
                 try:
                     root_member_name: str = (
-                        self.win.scene_model.puppets[name].get_root_members()[0].name
+                        self.scene_service.model.puppets[name]
+                        .get_root_members()[0]
+                        .name
                     )
                     root_piece = self.win.object_manager.graphics_items.get(
                         f"{name}:{root_member_name}"

--- a/ui/scene/puppet_ops.py
+++ b/ui/scene/puppet_ops.py
@@ -15,14 +15,16 @@ from core.svg_loader import SvgLoader
 
 if TYPE_CHECKING:
     from .scene_controller import MainWindowProtocol
+    from controllers.scene_service import SceneService
 
 
 class PuppetOps:
     """Operations related to puppet manipulation in the scene."""
 
-    def __init__(self, win: MainWindowProtocol) -> None:
-        """Initialize helper with a reference to the main window."""
+    def __init__(self, win: MainWindowProtocol, scene_service: SceneService) -> None:
+        """Initialize helper with a reference to la fenêtre et au service."""
         self.win = win
+        self.scene_service = scene_service
 
     def add_puppet(self, file_path: str, puppet_name: str) -> None:
         """Adds a puppet to the scene."""
@@ -54,7 +56,7 @@ class PuppetOps:
         except Exception:  # pylint: disable=broad-except
             logging.exception("Sidecar variants loading failed for %s", file_path)
         puppet.build_from_svg(loader)
-        self.win.scene_model.add_puppet(puppet_name, puppet)
+        self.scene_service.add_puppet(puppet_name, puppet)
         self.win.object_manager.puppet_scales[puppet_name] = 1.0
         self.win.object_manager.puppet_paths[puppet_name] = file_path
         self.win.object_manager.puppet_z_offsets[puppet_name] = 0
@@ -189,7 +191,7 @@ class PuppetOps:
                         self.win.scene.removeItem(piece.pivot_handle)
                     if piece.rotation_handle:
                         self.win.scene.removeItem(piece.rotation_handle)
-            self.win.scene_model.remove_puppet(puppet_name)
+            self.scene_service.remove_puppet(puppet_name)
             self.win.object_manager.puppet_scales.pop(puppet_name, None)
             self.win.object_manager.puppet_paths.pop(puppet_name, None)
             self.win.object_manager.puppet_z_offsets.pop(puppet_name, None)

--- a/ui/scene/scene_controller.py
+++ b/ui/scene/scene_controller.py
@@ -9,8 +9,9 @@ from PySide6.QtCore import QPointF
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsScene
 
 from core.scene_model import Keyframe, SceneModel, SceneObject
+from controllers.scene_service import SceneService
 from .state_applier import StateApplier
-from .scene_visuals import SceneVisuals
+from .scene_view import SceneView
 from ..onion_skin import OnionSkinManager
 from .puppet_ops import PuppetOps
 from .library_ops import LibraryOps, LibraryPayload
@@ -52,27 +53,29 @@ class SceneController:
         self,
         win: MainWindowProtocol,
         *,
-        visuals: SceneVisuals | None = None,
+        service: SceneService | None = None,
+        view: SceneView | None = None,
         onion: OnionSkinManager | None = None,
         applier: StateApplier | None = None,
     ) -> None:
         """Initialize the scene controller."""
         self.win = win
-        self.visuals: SceneVisuals = (
-            visuals if visuals is not None else SceneVisuals(win)
+        self.service = service if service is not None else SceneService(
+            win.scene_model, win.object_controller.capture_scene_state
         )
-        if visuals is None:
-            self.visuals.setup()
+        self.view = view if view is not None else SceneView(win)
         self.onion: OnionSkinManager = (
             onion if onion is not None else OnionSkinManager(win)
         )
         self.applier: StateApplier = (
             applier if applier is not None else StateApplier(win)
         )
-        self.puppet_ops = PuppetOps(win)
+        self.puppet_ops = PuppetOps(win, self.service)
         self.library_ops = LibraryOps(
-            win, self.puppet_ops, win.object_controller, self.set_background_path
+            win, self.puppet_ops, win.object_controller, self.service
         )
+        self.service.background_changed.connect(self.view.update_background)
+        self.service.scene_resized.connect(self.view.handle_scene_resized)
 
     # --- Puppet operations -------------------------------------------------
     def add_puppet(self, file_path: str, puppet_name: str) -> None:
@@ -118,31 +121,7 @@ class SceneController:
         """
         # Update visuals immediately
         self.puppet_ops.set_member_variant(puppet_name, slot, variant_name)
-        # Ensure there's a keyframe to store this change
-        cur = int(self.win.scene_model.current_frame)
-        try:
-            # Snapshot current state if the frame has no keyframe yet
-            if cur not in self.win.scene_model.keyframes:
-                self.win.controller.add_keyframe(cur)
-        except Exception:  # pylint: disable=broad-except
-            # Fallback: attempt to create an empty keyframe if UI path fails
-            self.win.scene_model.add_keyframe(
-                cur, self.win.object_controller.capture_scene_state()
-            )
-
-        kf = self.win.scene_model.keyframes.get(cur)
-        if not kf:
-            return
-        pup_map = kf.puppets.get(puppet_name)
-        if pup_map is None:
-            pup_map = {}
-            kf.puppets[puppet_name] = pup_map
-        vmap = pup_map.get("_variants")
-        if not isinstance(vmap, dict):
-            vmap = {}
-            pup_map["_variants"] = vmap
-        vmap[str(slot)] = str(variant_name)
-        # Re-apply scene from model to keep everything in sync (onion, etc.)
+        self.service.set_member_variant(puppet_name, slot, variant_name)
         try:
             self.win.controller.update_scene_from_model()
             self.win.update_onion_skins()
@@ -209,26 +188,20 @@ class SceneController:
     # --- Visuals -----------------------------------------------------------
     def update_scene_visuals(self) -> None:
         """Update scene visuals."""
-        self.visuals.update_scene_visuals()
+        self.view.update_scene_visuals()
 
     def update_background(self) -> None:
         """Update the scene background."""
-        self.visuals.update_background()
+        self.view.update_background()
 
     def set_background_path(self, path: Optional[str]) -> None:
         """Set the path for the scene background."""
-        self.win.scene_model.background_path = path
-        self.update_background()
+        self.service.set_background_path(path)
 
     # --- View & zoom ------------------------------------------------------
     def zoom(self, factor: float) -> None:
         """Zoom the view by a factor."""
-        self.win.view.scale(factor, factor)
-        self.win.zoom_factor *= factor
-        try:
-            self.win._update_zoom_status()
-        except (RuntimeError, AttributeError):
-            logging.exception("Failed to update zoom status")
+        self.view.zoom(factor)
 
     # --- Onion skin -------------------------------------------------------
     def set_onion_enabled(self, enabled: bool) -> None:
@@ -265,12 +238,4 @@ class SceneController:
     # --- Scene settings ---------------------------------------------------
     def set_scene_size(self, width: int, height: int) -> None:
         """Set the scene dimensions."""
-        self.win.scene_model.scene_width = int(width)
-        self.win.scene_model.scene_height = int(height)
-        self.win.scene.setSceneRect(0, 0, int(width), int(height))
-        self.update_scene_visuals()
-        self.update_background()
-        try:
-            self.win._update_zoom_status()
-        except (RuntimeError, AttributeError):
-            logging.exception("Failed to update zoom status after scene resize")
+        self.service.set_scene_size(width, height)

--- a/ui/scene/scene_view.py
+++ b/ui/scene/scene_view.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Regroupe les interactions directes avec la ``QGraphicsScene``."""
+
+from typing import Any
+import logging
+
+from PySide6.QtCore import QObject
+
+from .scene_visuals import SceneVisuals
+
+
+class SceneView(QObject):
+    """Encapsule la logique liée à l'affichage de la scène."""
+
+    def __init__(self, win: Any, visuals: SceneVisuals | None = None) -> None:
+        super().__init__()
+        self.win = win
+        self.visuals: SceneVisuals = visuals if visuals is not None else SceneVisuals(win)
+        if visuals is None:
+            self.visuals.setup()
+
+    # ------------------------------------------------------------------
+    def update_scene_visuals(self) -> None:
+        """Met à jour les éléments graphiques de la scène."""
+        self.visuals.update_scene_visuals()
+
+    def update_background(self, _path: object | None = None) -> None:
+        """Met à jour l'arrière-plan de la scène."""
+        self.visuals.update_background()
+
+    def handle_scene_resized(self, width: int, height: int) -> None:
+        """Applique une nouvelle taille de scène au ``QGraphicsScene``."""
+        self.win.scene.setSceneRect(0, 0, int(width), int(height))
+        self.update_scene_visuals()
+        self.update_background()
+        try:
+            self.win._update_zoom_status()
+        except (RuntimeError, AttributeError):
+            logging.exception("Failed to update zoom status after scene resize")
+
+    def zoom(self, factor: float) -> None:
+        """Applique un zoom sur la vue."""
+        self.win.view.scale(factor, factor)
+        self.win.zoom_factor *= factor
+        try:
+            self.win._update_zoom_status()
+        except (RuntimeError, AttributeError):
+            logging.exception("Failed to update zoom status")


### PR DESCRIPTION
## Résumé
- Ajouter `SceneService` centralisant les opérations sur le modèle (pantins, variants, keyframes, taille, arrière-plan).
- Introduire `SceneView` pour toutes les interactions `QGraphicsScene` et les visuels de scène.
- Refactoriser `SceneController` en orchestrateur reliant service et vue par signaux.
- Adapter `PuppetOps`, `LibraryOps`, `AppController` et `MainWindow` pour utiliser le nouveau service.

## Tests
- `pytest -q`
- `pylint core ui macronotron.py`


------
https://chatgpt.com/codex/tasks/task_e_68a329939c4c832bb7f0ede6a00a02ca