### PR TITLE
tests: isoler la logique des services

### DIFF
--- a/tests/test_app_controller.py
+++ b/tests/test_app_controller.py
@@ -1,0 +1,39 @@
+"""Tests unitaires pour ``AppController``."""
+
+from controllers.app_controller import AppController
+from controllers.scene_service import SceneService
+from core.scene_model import SceneModel
+
+
+class _DummyTimeline:
+    """Widget factice enregistrant les marqueurs de keyframe."""
+
+    def __init__(self) -> None:
+        self.markers: list[int] = []
+
+    def add_keyframe_marker(self, frame_index: int) -> None:
+        self.markers.append(int(frame_index))
+
+
+class _DummySceneController:
+    """SceneController minimal exposant un ``SceneService``."""
+
+    def __init__(self, model: SceneModel) -> None:
+        self.service = SceneService(model, lambda: {"puppets": {}, "objects": {}})
+
+
+class _DummyWindow:
+    """Fenêtre minimale utilisée par ``AppController``."""
+
+    def __init__(self) -> None:
+        self.scene_model = SceneModel()
+        self.timeline_widget = _DummyTimeline()
+        self.scene_controller = _DummySceneController(self.scene_model)
+
+
+def test_add_keyframe_updates_model() -> None:
+    win = _DummyWindow()
+    ctrl = AppController(win)
+    ctrl.add_keyframe(5)
+    assert 5 in win.scene_model.keyframes
+    assert win.timeline_widget.markers == [5]

--- a/tests/test_object_controller.py
+++ b/tests/test_object_controller.py
@@ -63,11 +63,9 @@ def test_add_and_remove_object() -> None:
     obj = SceneObject("test", "svg", "path.svg")
     ctrl.add_object(obj)
     assert "test" in ctrl.model.objects
-    assert "test" in ctrl.view.objects
 
     ctrl.remove_object("test")
     assert "test" not in ctrl.model.objects
-    assert "test" not in ctrl.view.objects
 
 
 def test_attach_and_detach_updates_model_and_keyframe() -> None:

--- a/tests/test_scene_controller.py
+++ b/tests/test_scene_controller.py
@@ -1,10 +1,9 @@
-from ui.scene import SceneController
-
 """Tests for the SceneController class."""
 
 import pytest
 from PySide6.QtWidgets import QApplication
 
+from ui.scene import SceneController
 from ui.main_window import MainWindow
 
 
@@ -17,13 +16,11 @@ def app():
     return qapp
 
 
-def test_set_scene_size_updates_model_and_scene(_app):
-    """Test that setting the scene size updates the model and the scene."""
+def test_set_scene_size_updates_scene(_app):
+    """The controller updates the graphics view size."""
     win = MainWindow()
     assert isinstance(win.scene_controller, SceneController)
     win.scene_controller.set_scene_size(800, 600)
-    assert win.scene_model.scene_width == 800
-    assert win.scene_model.scene_height == 600
     rect = win.scene.sceneRect()
     assert rect.width() == 800
     assert rect.height() == 600

--- a/tests/test_scene_service.py
+++ b/tests/test_scene_service.py
@@ -1,0 +1,53 @@
+"""Tests unitaires pour ``SceneService``."""
+from __future__ import annotations
+
+
+from typing import Dict
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from controllers.scene_service import SceneService
+from core.scene_model import SceneModel
+
+
+@pytest.fixture()
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def _provider(state: Dict[str, Dict] | None = None):
+    def _inner() -> Dict[str, Dict]:
+        return state or {"puppets": {}, "objects": {}}
+    return _inner
+
+
+def test_add_keyframe_uses_provider(app):  # noqa: ARG001
+    model = SceneModel()
+    service = SceneService(model, _provider({"objects": {"o": {"x": 1}}, "puppets": {}}))
+    service.add_keyframe(3)
+    assert model.keyframes[3].objects["o"]["x"] == 1
+
+
+def test_set_member_variant_creates_keyframe(app):  # noqa: ARG001
+    model = SceneModel()
+    service = SceneService(model, _provider())
+    service.set_member_variant("p", "hand", "alt")
+    kf = model.keyframes[0]
+    assert kf.puppets["p"]["_variants"]["hand"] == "alt"
+
+
+def test_background_and_size_signals(app):  # noqa: ARG001
+    model = SceneModel()
+    service = SceneService(model, _provider())
+    bg_emitted: list[str | None] = []
+    size_emitted: list[tuple[int, int]] = []
+    service.background_changed.connect(lambda p: bg_emitted.append(p))
+    service.scene_resized.connect(lambda w, h: size_emitted.append((w, h)))
+    service.set_background_path("bg.png")
+    service.set_scene_size(640, 480)
+    assert model.background_path == "bg.png"
+    assert model.scene_width == 640
+    assert model.scene_height == 480
+    assert bg_emitted == ["bg.png"]
+    assert size_emitted == [(640, 480)]


### PR DESCRIPTION
## Résumé
- Ajouter des tests unitaires pour `AppController` et `SceneService`
- Vérifier `ObjectController` sans dépendance vue
- Conserver le test du `SceneController` en se limitant aux effets graphiques

## Détails
- Simulations de vues via objets factices pour tester uniquement les modèles
- Vérification des signaux de `SceneService` et des marqueurs d'`AppController`

## Tests
- `pylint core ui macronotron.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a341fba33c832b9bcb45db3bde9d77