### PR TITLE
Retirer les presets de thème

### DIFF
--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -874,7 +874,6 @@ class SettingsDialog(QDialog):
         css = build_stylesheet(self._params_from_ui())
         s = QSettings("JaJa", "Macronotron")
         s.setValue("ui/custom_stylesheet", css)
-        s.setValue("ui/theme", "custom")
 
     def _update_swatch(self, edit: QLineEdit) -> None:
         """

--- a/ui/settings_manager.py
+++ b/ui/settings_manager.py
@@ -133,104 +133,93 @@ class SettingsManager:
             dlg.icon_size_spin.setValue(int(s.value("ui/icon_size", 32)))
         except (TypeError, ValueError):
             dlg.icon_size_spin.setValue(32)
-        theme = str(s.value("ui/theme", "dark")).lower()
         try:
-            presets_map = {
-                "light": "Light",
-                "dark": "Dark",
-                "high contrast": "High Contrast",
-                "custom": "Custom",
-            }
-            dlg.preset_combo.setCurrentText(presets_map.get(theme, "Dark"))
-            if theme == "custom":
-                # Load from theme file if present, else from custom_params
-                from pathlib import Path
+            dlg.preset_combo.setCurrentText("Custom")
+            from pathlib import Path
 
-                theme_path = s.value("ui/theme_file") or str(
-                    Path.home() / ".config/JaJa/Macronotron/theme.json"
+            theme_path = s.value("ui/theme_file") or str(
+                Path.home() / ".config/JaJa/Macronotron/theme.json"
+            )
+            try:
+                p = Path(str(theme_path))
+                if p.exists():
+                    import json
+
+                    data = json.load(p.open("r", encoding="utf-8"))
+                    if isinstance(data, dict):
+                        for k, v in data.items():
+                            s.setValue(f"ui/custom_params/{k}", v)
+            except Exception:
+                logging.exception("Failed to read theme file")
+            s.beginGroup("ui/custom_params")
+
+            def _gv(key: str, default: str) -> str:
+                v = s.value(key)
+                return str(v) if v not in [None, ""] else default
+
+            try:
+                dlg.bg_edit.setText(_gv("bg_color", "#E2E8F0"))
+                dlg.text_edit.setText(_gv("text_color", "#1A202C"))
+                dlg.accent_edit.setText(_gv("accent_color", "#E53E3E"))
+                dlg.hover_edit.setText(_gv("hover_color", "#E3E6FD"))
+                dlg.panel_edit.setText(_gv("panel_bg", "#F7F8FC"))
+                dlg.border_edit.setText(_gv("panel_border", "#D0D5DD"))
+                dlg.group_edit.setText(_gv("group_title_color", "#2D3748"))
+                dlg.tooltip_bg_edit.setText(
+                    _gv("tooltip_bg", dlg.panel_edit.text())
                 )
+                dlg.tooltip_text_edit.setText(
+                    _gv("tooltip_text", dlg.text_edit.text())
+                )
+                # Nouveaux champs exposés
+                dlg.input_bg_edit.setText(_gv("input_bg", "#EDF2F7"))
+                dlg.input_border_edit.setText(_gv("input_border", "#CBD5E0"))
+                dlg.input_text_edit.setText(_gv("input_text", dlg.text_edit.text()))
+                dlg.input_focus_bg_edit.setText(_gv("input_focus_bg", "#FFFFFF"))
+                dlg.input_focus_border_edit.setText(
+                    _gv("input_focus_border", dlg.accent_edit.text())
+                )
+                dlg.list_hover_edit.setText(_gv("list_hover_bg", "#E2E8F0"))
+                dlg.list_sel_bg_edit.setText(
+                    _gv("list_selected_bg", dlg.accent_edit.text())
+                )
+                dlg.list_sel_text_edit.setText(_gv("list_selected_text", "#FFFFFF"))
+                dlg.cb_un_bg_edit.setText(_gv("checkbox_unchecked_bg", "#EDF2F7"))
+                dlg.cb_un_border_edit.setText(
+                    _gv("checkbox_unchecked_border", "#A0AEC0")
+                )
+                dlg.cb_ch_bg_edit.setText(
+                    _gv("checkbox_checked_bg", dlg.accent_edit.text())
+                )
+                dlg.cb_ch_border_edit.setText(
+                    _gv("checkbox_checked_border", "#C53030")
+                )
+                dlg.cb_ch_hover_edit.setText(
+                    _gv("checkbox_checked_hover", "#F56565")
+                )
+                # Numeric params
                 try:
-                    p = Path(str(theme_path))
-                    if p.exists():
-                        import json
-
-                        data = json.load(p.open("r", encoding="utf-8"))
-                        if isinstance(data, dict):
-                            for k, v in data.items():
-                                s.setValue(f"ui/custom_params/{k}", v)
-                except Exception:
-                    logging.exception("Failed to read theme file")
-                s.beginGroup("ui/custom_params")
-
-                def _gv(key: str, default: str) -> str:
-                    v = s.value(key)
-                    return str(v) if v not in [None, ""] else default
-
-                try:
-                    dlg.bg_edit.setText(_gv("bg_color", "#E2E8F0"))
-                    dlg.text_edit.setText(_gv("text_color", "#1A202C"))
-                    dlg.accent_edit.setText(_gv("accent_color", "#E53E3E"))
-                    dlg.hover_edit.setText(_gv("hover_color", "#E3E6FD"))
-                    dlg.panel_edit.setText(_gv("panel_bg", "#F7F8FC"))
-                    dlg.border_edit.setText(_gv("panel_border", "#D0D5DD"))
-                    dlg.group_edit.setText(_gv("group_title_color", "#2D3748"))
-                    dlg.tooltip_bg_edit.setText(
-                        _gv("tooltip_bg", dlg.panel_edit.text())
-                    )
-                    dlg.tooltip_text_edit.setText(
-                        _gv("tooltip_text", dlg.text_edit.text())
-                    )
-                    # Nouveaux champs exposés
-                    dlg.input_bg_edit.setText(_gv("input_bg", "#EDF2F7"))
-                    dlg.input_border_edit.setText(_gv("input_border", "#CBD5E0"))
-                    dlg.input_text_edit.setText(_gv("input_text", dlg.text_edit.text()))
-                    dlg.input_focus_bg_edit.setText(_gv("input_focus_bg", "#FFFFFF"))
-                    dlg.input_focus_border_edit.setText(
-                        _gv("input_focus_border", dlg.accent_edit.text())
-                    )
-                    dlg.list_hover_edit.setText(_gv("list_hover_bg", "#E2E8F0"))
-                    dlg.list_sel_bg_edit.setText(
-                        _gv("list_selected_bg", dlg.accent_edit.text())
-                    )
-                    dlg.list_sel_text_edit.setText(_gv("list_selected_text", "#FFFFFF"))
-                    dlg.cb_un_bg_edit.setText(_gv("checkbox_unchecked_bg", "#EDF2F7"))
-                    dlg.cb_un_border_edit.setText(
-                        _gv("checkbox_unchecked_border", "#A0AEC0")
-                    )
-                    dlg.cb_ch_bg_edit.setText(
-                        _gv("checkbox_checked_bg", dlg.accent_edit.text())
-                    )
-                    dlg.cb_ch_border_edit.setText(
-                        _gv("checkbox_checked_border", "#C53030")
-                    )
-                    dlg.cb_ch_hover_edit.setText(
-                        _gv("checkbox_checked_hover", "#F56565")
-                    )
-                    # Numeric params
-                    try:
-                        dlg.opacity_spin.setValue(
-                            int(float(s.value("panel_opacity", 0.9)) * 100)
-                        )
-                    except Exception:
-                        dlg.opacity_spin.setValue(90)
-                    dlg.radius_spin.setValue(int(s.value("radius", 12) or 12))
-                    dlg.font_spin.setValue(int(s.value("font_size", 10) or 10))
-                    dlg.font_family_edit.setText(
-                        _gv("font_family", str(s.value("ui/font_family") or "Poppins"))
+                    dlg.opacity_spin.setValue(
+                        int(float(s.value("panel_opacity", 0.9)) * 100)
                     )
                 except Exception:
-                    logging.exception("Failed to load custom params")
-                finally:
-                    s.endGroup()
-                try:
-                    dlg._update_all_swatches()
-                    dlg._preview_theme()
-                except Exception:
-                    pass
-            else:
-                dlg._load_preset_values(dlg.preset_combo.currentText())
+                    dlg.opacity_spin.setValue(90)
+                dlg.radius_spin.setValue(int(s.value("radius", 12) or 12))
+                dlg.font_spin.setValue(int(s.value("font_size", 10) or 10))
+                dlg.font_family_edit.setText(
+                    _gv("font_family", str(s.value("ui/font_family") or "Poppins"))
+                )
+            except Exception:
+                logging.exception("Failed to load custom params")
+            finally:
+                s.endGroup()
+            try:
+                dlg._update_all_swatches()
+                dlg._preview_theme()
+            except Exception:
+                pass
         except (RuntimeError, AttributeError):
-            logging.exception("Failed to load preset/custom values")
+            logging.exception("Failed to load custom values")
         # Font family default if not set via custom
         try:
             if not dlg.font_family_edit.text().strip():
@@ -363,10 +352,7 @@ class SettingsManager:
                     "ui/font_family", dlg.font_family_edit.text().strip() or "Poppins"
                 )
                 # theme
-                theme = dlg.preset_combo.currentText().strip().lower() or "light"
-                s.setValue("ui/theme", theme)
-                if theme == "custom":
-                    params = {
+                params = {
                         "bg_color": dlg.bg_edit.text() or "#E2E8F0",
                         "text_color": dlg.text_edit.text() or "#1A202C",
                         "accent_color": dlg.accent_edit.text() or "#E53E3E",
@@ -410,29 +396,29 @@ class SettingsManager:
                         or "#C53030",
                         "checkbox_checked_hover": dlg.cb_ch_hover_edit.text()
                         or "#F56565",
-                    }
-                    css = build_stylesheet(params)
-                    s.setValue("ui/custom_stylesheet", css)
-                    # Save to theme file for persistence beyond resets
-                    from pathlib import Path
+                }
+                css = build_stylesheet(params)
+                s.setValue("ui/custom_stylesheet", css)
+                # Save to theme file for persistence beyond resets
+                from pathlib import Path
 
-                    theme_path = s.value("ui/theme_file") or str(
-                        Path.home() / ".config/JaJa/Macronotron/theme.json"
-                    )
-                    try:
-                        p = Path(str(theme_path))
-                        p.parent.mkdir(parents=True, exist_ok=True)
-                        import json
+                theme_path = s.value("ui/theme_file") or str(
+                    Path.home() / ".config/JaJa/Macronotron/theme.json"
+                )
+                try:
+                    p = Path(str(theme_path))
+                    p.parent.mkdir(parents=True, exist_ok=True)
+                    import json
 
-                        p.write_text(json.dumps(params, indent=2), encoding="utf-8")
-                        s.setValue("ui/theme_file", str(p))
-                    except Exception:
-                        logging.exception("Failed to write theme file")
-                    # Keep QSettings copy for compatibility
-                    s.beginGroup("ui/custom_params")
-                    for k, v in params.items():
-                        s.setValue(k, v)
-                    s.endGroup()
+                    p.write_text(json.dumps(params, indent=2), encoding="utf-8")
+                    s.setValue("ui/theme_file", str(p))
+                except Exception:
+                    logging.exception("Failed to write theme file")
+                # Keep QSettings copy for compatibility
+                s.beginGroup("ui/custom_params")
+                for k, v in params.items():
+                    s.setValue(k, v)
+                s.endGroup()
                 # scene bg
                 scene_bg = dlg.scene_bg_edit.text().strip()
                 s.setValue("ui/style/scene_bg", scene_bg)
@@ -514,36 +500,34 @@ class SettingsManager:
 
                 prof = UIProfile()
                 # Récupère les champs du dialog
-                prof.theme.preset = dlg.preset_combo.currentText().strip().lower()
                 prof.theme.font_family = (
                     dlg.font_family_edit.text().strip() or "Poppins"
                 )
-                if prof.theme.preset == "custom":
-                    prof.theme.custom_params.update(
-                        {
-                            "bg_color": dlg.bg_edit.text() or "#E2E8F0",
-                            "text_color": dlg.text_edit.text() or "#1A202C",
-                            "accent_color": dlg.accent_edit.text() or "#E53E3E",
-                            "hover_color": dlg.hover_edit.text() or "#E3E6FD",
-                            "panel_bg": dlg.panel_edit.text() or "#F7F8FC",
-                            "panel_opacity": (dlg.opacity_spin.value() / 100.0),
-                            "panel_border": dlg.border_edit.text() or "#D0D5DD",
-                            "header_bg": dlg.header_bg_edit.text() or "",
-                            "header_text": dlg.header_text_edit.text()
-                            or dlg.text_edit.text()
-                            or "#1A202C",
-                            "header_border": dlg.header_border_edit.text()
-                            or dlg.border_edit.text()
-                            or "#D0D5DD",
-                            "group_title_color": dlg.group_edit.text() or "#2D3748",
-                            "tooltip_bg": dlg.tooltip_bg_edit.text() or "#F7F8FC",
-                            "tooltip_text": dlg.tooltip_text_edit.text() or "#1A202C",
-                            "tooltip_border": dlg.border_edit.text() or "#D0D5DD",
-                            "radius": dlg.radius_spin.value(),
-                            "font_size": dlg.font_spin.value(),
-                            "font_family": dlg.font_family_edit.text() or "Poppins",
-                        }
-                    )
+                prof.theme.custom_params.update(
+                    {
+                        "bg_color": dlg.bg_edit.text() or "#E2E8F0",
+                        "text_color": dlg.text_edit.text() or "#1A202C",
+                        "accent_color": dlg.accent_edit.text() or "#E53E3E",
+                        "hover_color": dlg.hover_edit.text() or "#E3E6FD",
+                        "panel_bg": dlg.panel_edit.text() or "#F7F8FC",
+                        "panel_opacity": (dlg.opacity_spin.value() / 100.0),
+                        "panel_border": dlg.border_edit.text() or "#D0D5DD",
+                        "header_bg": dlg.header_bg_edit.text() or "",
+                        "header_text": dlg.header_text_edit.text()
+                        or dlg.text_edit.text()
+                        or "#1A202C",
+                        "header_border": dlg.header_border_edit.text()
+                        or dlg.border_edit.text()
+                        or "#D0D5DD",
+                        "group_title_color": dlg.group_edit.text() or "#2D3748",
+                        "tooltip_bg": dlg.tooltip_bg_edit.text() or "#F7F8FC",
+                        "tooltip_text": dlg.tooltip_text_edit.text() or "#1A202C",
+                        "tooltip_border": dlg.border_edit.text() or "#D0D5DD",
+                        "radius": dlg.radius_spin.value(),
+                        "font_size": dlg.font_spin.value(),
+                        "font_family": dlg.font_family_edit.text() or "Poppins",
+                    }
+                )
                 prof.icon_dir = dlg.icon_dir_edit.text().strip() or None
                 prof.icon_size = int(dlg.icon_size_spin.value())
                 if hasattr(dlg, "icon_norm_edit"):
@@ -601,46 +585,37 @@ class SettingsManager:
                     return
                 prof = UIProfile.import_json(path)
                 # Renseigne les champs du dialog seulement
-                presets_map = {
-                    "light": "Light",
-                    "dark": "Dark",
-                    "high contrast": "High Contrast",
-                    "custom": "Custom",
-                }
-                dlg.preset_combo.setCurrentText(
-                    presets_map.get(prof.theme.preset, "Dark")
-                )
+                dlg.preset_combo.setCurrentText("Custom")
                 dlg.font_family_edit.setText(prof.theme.font_family or "Poppins")
-                if prof.theme.preset == "custom":
-                    cp = prof.theme.custom_params
-                    dlg.bg_edit.setText(str(cp.get("bg_color", "#E2E8F0")))
-                    dlg.text_edit.setText(str(cp.get("text_color", "#1A202C")))
-                    dlg.accent_edit.setText(str(cp.get("accent_color", "#E53E3E")))
-                    dlg.hover_edit.setText(str(cp.get("hover_color", "#E3E6FD")))
-                    dlg.panel_edit.setText(str(cp.get("panel_bg", "#F7F8FC")))
-                    dlg.border_edit.setText(str(cp.get("panel_border", "#D0D5DD")))
-                    dlg.header_bg_edit.setText(str(cp.get("header_bg", "")))
-                    dlg.header_text_edit.setText(
-                        str(cp.get("header_text", dlg.text_edit.text()))
+                cp = prof.theme.custom_params
+                dlg.bg_edit.setText(str(cp.get("bg_color", "#E2E8F0")))
+                dlg.text_edit.setText(str(cp.get("text_color", "#1A202C")))
+                dlg.accent_edit.setText(str(cp.get("accent_color", "#E53E3E")))
+                dlg.hover_edit.setText(str(cp.get("hover_color", "#E3E6FD")))
+                dlg.panel_edit.setText(str(cp.get("panel_bg", "#F7F8FC")))
+                dlg.border_edit.setText(str(cp.get("panel_border", "#D0D5DD")))
+                dlg.header_bg_edit.setText(str(cp.get("header_bg", "")))
+                dlg.header_text_edit.setText(
+                    str(cp.get("header_text", dlg.text_edit.text()))
+                )
+                dlg.header_border_edit.setText(
+                    str(cp.get("header_border", dlg.border_edit.text()))
+                )
+                dlg.group_edit.setText(str(cp.get("group_title_color", "#2D3748")))
+                dlg.tooltip_bg_edit.setText(
+                    str(cp.get("tooltip_bg", dlg.panel_edit.text()))
+                )
+                dlg.tooltip_text_edit.setText(
+                    str(cp.get("tooltip_text", dlg.text_edit.text()))
+                )
+                try:
+                    dlg.opacity_spin.setValue(
+                        int(float(cp.get("panel_opacity", 0.9)) * 100)
                     )
-                    dlg.header_border_edit.setText(
-                        str(cp.get("header_border", dlg.border_edit.text()))
-                    )
-                    dlg.group_edit.setText(str(cp.get("group_title_color", "#2D3748")))
-                    dlg.tooltip_bg_edit.setText(
-                        str(cp.get("tooltip_bg", dlg.panel_edit.text()))
-                    )
-                    dlg.tooltip_text_edit.setText(
-                        str(cp.get("tooltip_text", dlg.text_edit.text()))
-                    )
-                    try:
-                        dlg.opacity_spin.setValue(
-                            int(float(cp.get("panel_opacity", 0.9)) * 100)
-                        )
-                    except Exception:
-                        dlg.opacity_spin.setValue(90)
-                    dlg.radius_spin.setValue(int(cp.get("radius", 12)))
-                    dlg.font_spin.setValue(int(cp.get("font_size", 10)))
+                except Exception:
+                    dlg.opacity_spin.setValue(90)
+                dlg.radius_spin.setValue(int(cp.get("radius", 12)))
+                dlg.font_spin.setValue(int(cp.get("font_size", 10)))
                 dlg.icon_dir_edit.setText(str(prof.icon_dir or ""))
                 dlg.icon_size_spin.setValue(int(prof.icon_size))
                 if hasattr(dlg, "icon_norm_edit"):
@@ -684,10 +659,25 @@ class SettingsManager:
 
         def _reset_profile_default() -> None:
             try:
-                prof = UIProfile.default_dark()
-                # Mettez les champs aux valeurs défaut Dark
-                dlg.preset_combo.setCurrentText("Dark")
+                prof = UIProfile()
+                dlg.preset_combo.setCurrentText("Custom")
                 dlg.font_family_edit.setText(prof.theme.font_family)
+                cp = prof.theme.custom_params
+                dlg.bg_edit.setText(str(cp.get("bg_color", "#E2E8F0")))
+                dlg.text_edit.setText(str(cp.get("text_color", "#1A202C")))
+                dlg.accent_edit.setText(str(cp.get("accent_color", "#E53E3E")))
+                dlg.hover_edit.setText(str(cp.get("hover_color", "#E3E6FD")))
+                dlg.panel_edit.setText(str(cp.get("panel_bg", "#F7F8FC")))
+                dlg.border_edit.setText(str(cp.get("panel_border", "#D0D5DD")))
+                dlg.group_edit.setText(str(cp.get("group_title_color", "#2D3748")))
+                dlg.tooltip_bg_edit.setText(str(cp.get("tooltip_bg", dlg.panel_edit.text())))
+                dlg.tooltip_text_edit.setText(str(cp.get("tooltip_text", dlg.text_edit.text())))
+                try:
+                    dlg.opacity_spin.setValue(int(float(cp.get("panel_opacity", 0.9)) * 100))
+                except Exception:
+                    dlg.opacity_spin.setValue(90)
+                dlg.radius_spin.setValue(int(cp.get("radius", 12)))
+                dlg.font_spin.setValue(int(cp.get("font_size", 10)))
                 # Timeline / icônes vers valeurs par défaut
                 dlg.icon_dir_edit.setText("")
                 dlg.icon_size_spin.setValue(int(prof.icon_size))
@@ -720,62 +710,58 @@ class SettingsManager:
             # Construire un profil complet à partir des champs et l'appliquer
             try:
                 prof = UIProfile()
-                prof.theme.preset = (
-                    dlg.preset_combo.currentText().strip().lower() or "dark"
-                )
                 prof.theme.font_family = (
                     dlg.font_family_edit.text().strip() or "Poppins"
                 )
-                if prof.theme.preset == "custom":
-                    prof.theme.custom_params.update(
-                        {
-                            "bg_color": dlg.bg_edit.text() or "#E2E8F0",
-                            "text_color": dlg.text_edit.text() or "#1A202C",
-                            "accent_color": dlg.accent_edit.text() or "#E53E3E",
-                            "hover_color": dlg.hover_edit.text() or "#E3E6FD",
-                            "panel_bg": dlg.panel_edit.text() or "#F7F8FC",
-                            "panel_opacity": (dlg.opacity_spin.value() / 100.0),
-                            "panel_border": dlg.border_edit.text() or "#D0D5DD",
-                            "header_bg": dlg.header_bg_edit.text() or "",
-                            "header_text": dlg.header_text_edit.text()
-                            or dlg.text_edit.text()
-                            or "#1A202C",
-                            "header_border": dlg.header_border_edit.text()
-                            or dlg.border_edit.text()
-                            or "#D0D5DD",
-                            "group_title_color": dlg.group_edit.text() or "#2D3748",
-                            "tooltip_bg": dlg.tooltip_bg_edit.text() or "#F7F8FC",
-                            "tooltip_text": dlg.tooltip_text_edit.text() or "#1A202C",
-                            "tooltip_border": dlg.border_edit.text() or "#D0D5DD",
-                            "radius": dlg.radius_spin.value(),
-                            "font_size": dlg.font_spin.value(),
-                            "font_family": dlg.font_family_edit.text() or "Poppins",
-                            # Champs supplémentaires exposés
-                            "input_bg": dlg.input_bg_edit.text() or "#EDF2F7",
-                            "input_border": dlg.input_border_edit.text() or "#CBD5E0",
-                            "input_text": dlg.input_text_edit.text()
-                            or (dlg.text_edit.text() or "#1A202C"),
-                            "input_focus_bg": dlg.input_focus_bg_edit.text()
-                            or "#FFFFFF",
-                            "input_focus_border": dlg.input_focus_border_edit.text()
-                            or (dlg.accent_edit.text() or "#E53E3E"),
-                            "list_hover_bg": dlg.list_hover_edit.text() or "#E2E8F0",
-                            "list_selected_bg": dlg.list_sel_bg_edit.text()
-                            or (dlg.accent_edit.text() or "#E53E3E"),
-                            "list_selected_text": dlg.list_sel_text_edit.text()
-                            or "#FFFFFF",
-                            "checkbox_unchecked_bg": dlg.cb_un_bg_edit.text()
-                            or "#EDF2F7",
-                            "checkbox_unchecked_border": dlg.cb_un_border_edit.text()
-                            or "#A0AEC0",
-                            "checkbox_checked_bg": dlg.cb_ch_bg_edit.text()
-                            or (dlg.accent_edit.text() or "#E53E3E"),
-                            "checkbox_checked_border": dlg.cb_ch_border_edit.text()
-                            or "#C53030",
-                            "checkbox_checked_hover": dlg.cb_ch_hover_edit.text()
-                            or "#F56565",
-                        }
-                    )
+                prof.theme.custom_params.update(
+                    {
+                        "bg_color": dlg.bg_edit.text() or "#E2E8F0",
+                        "text_color": dlg.text_edit.text() or "#1A202C",
+                        "accent_color": dlg.accent_edit.text() or "#E53E3E",
+                        "hover_color": dlg.hover_edit.text() or "#E3E6FD",
+                        "panel_bg": dlg.panel_edit.text() or "#F7F8FC",
+                        "panel_opacity": (dlg.opacity_spin.value() / 100.0),
+                        "panel_border": dlg.border_edit.text() or "#D0D5DD",
+                        "header_bg": dlg.header_bg_edit.text() or "",
+                        "header_text": dlg.header_text_edit.text()
+                        or dlg.text_edit.text()
+                        or "#1A202C",
+                        "header_border": dlg.header_border_edit.text()
+                        or dlg.border_edit.text()
+                        or "#D0D5DD",
+                        "group_title_color": dlg.group_edit.text() or "#2D3748",
+                        "tooltip_bg": dlg.tooltip_bg_edit.text() or "#F7F8FC",
+                        "tooltip_text": dlg.tooltip_text_edit.text() or "#1A202C",
+                        "tooltip_border": dlg.border_edit.text() or "#D0D5DD",
+                        "radius": dlg.radius_spin.value(),
+                        "font_size": dlg.font_spin.value(),
+                        "font_family": dlg.font_family_edit.text() or "Poppins",
+                        # Champs supplémentaires exposés
+                        "input_bg": dlg.input_bg_edit.text() or "#EDF2F7",
+                        "input_border": dlg.input_border_edit.text() or "#CBD5E0",
+                        "input_text": dlg.input_text_edit.text()
+                        or (dlg.text_edit.text() or "#1A202C"),
+                        "input_focus_bg": dlg.input_focus_bg_edit.text()
+                        or "#FFFFFF",
+                        "input_focus_border": dlg.input_focus_border_edit.text()
+                        or (dlg.accent_edit.text() or "#E53E3E"),
+                        "list_hover_bg": dlg.list_hover_edit.text() or "#E2E8F0",
+                        "list_selected_bg": dlg.list_sel_bg_edit.text()
+                        or (dlg.accent_edit.text() or "#E53E3E"),
+                        "list_selected_text": dlg.list_sel_text_edit.text()
+                        or "#FFFFFF",
+                        "checkbox_unchecked_bg": dlg.cb_un_bg_edit.text()
+                        or "#EDF2F7",
+                        "checkbox_unchecked_border": dlg.cb_un_border_edit.text()
+                        or "#A0AEC0",
+                        "checkbox_checked_bg": dlg.cb_ch_bg_edit.text()
+                        or (dlg.accent_edit.text() or "#E53E3E"),
+                        "checkbox_checked_border": dlg.cb_ch_border_edit.text()
+                        or "#C53030",
+                        "checkbox_checked_hover": dlg.cb_ch_hover_edit.text()
+                        or "#F56565",
+                    }
+                )
                 # Icônes/timeline/menus/scène
                 prof.icon_dir = dlg.icon_dir_edit.text().strip() or None
                 prof.icon_size = int(dlg.icon_size_spin.value())

--- a/ui/styles.py
+++ b/ui/styles.py
@@ -1,187 +1,12 @@
 """Module for managing application styles and themes."""
 
 import logging
+from typing import Any
 from PySide6.QtGui import QFont
-from .theme_settings import ThemeSettings
+from .ui_profile import UIProfile
 
 # This is used for the fallback icon drawing function.
 ICON_COLOR = "#2D3748"
-
-STYLE_SHEET_LIGHT = """
-/* GLOBAL SETTINGS */
-* {
-    color: #1A202C; /* Default dark text */
-    font-family: Poppins, sans-serif;
-}
-
-/* MAIN WINDOW & VIEW */
-QMainWindow, QDialog {
-    background-color: #E2E8F0; /* Light grey background */
-}
-
-QGraphicsView {
-    border: none;
-}
-
-/* PANELS & DOCKS (Library, Inspector, Timeline) */
-DraggableOverlay, PanelOverlay {
-    background-color: rgba(247, 248, 252, 0.9); /* Semi-transparent white */
-    border-radius: 12px;
-    border: 1px solid #D0D5DD;
-}
-
-DraggableHeader { background-color: rgba(237, 242, 247, 0.9); border-bottom: 1px solid rgba(203, 213, 224, 0.5); border-top-left-radius: 12px; border-top-right-radius: 12px; }
-DraggableHeader QLabel { font-weight: bold; color: #2D3748; }
-
-
-/* TOOL BUTTONS & ICONS */
-QToolButton {
-    background-color: transparent;
-    border: none;
-    border-radius: 6px;
-    padding: 5px;
-}
-
-QToolButton:hover {
-    background-color: #E3E6FD; /* Lavender hover */
-}
-
-QToolButton:checked {
-    background-color: #E53E3E; /* Red background when active */
-}
-
-
-/* WIDGETS (Inputs, Lists, etc.) */
-QLineEdit, QDoubleSpinBox, QSpinBox, QComboBox {
-    background-color: #EDF2F7;
-    border: 1px solid #CBD5E0;
-    border-radius: 4px;
-    padding: 4px;
-    color: #1A202C;
-}
-
-QLineEdit:focus, QDoubleSpinBox:focus, QSpinBox:focus, QComboBox:focus {
-    border-color: #E53E3E;
-    background-color: white;
-}
-
-QTreeView, QListWidget {
-    background-color: transparent;
-    border: none;
-}
-
-QTreeView::item, QListWidget::item {
-    padding: 4px;
-    border-radius: 4px;
-}
-
-QTreeView::item:hover, QListWidget::item:hover {
-    background-color: #E2E8F0;
-}
-
-QTreeView::item:selected, QListWidget::item:selected {
-    background-color: #E53E3E;
-    color: white;
-}
-
-QScrollArea {
-    border: none;
-}
-
-/* CHECKBOXES: Improve contrast and checked visibility */
-QCheckBox {
-    spacing: 6px;
-}
-QCheckBox::indicator {
-    width: 16px; height: 16px;
-    border-radius: 3px;
-}
-QCheckBox::indicator:unchecked {
-    background-color: #EDF2F7;
-    border: 1px solid #A0AEC0;
-}
-QCheckBox::indicator:unchecked:hover {
-    background-color: #E2E8F0;
-}
-QCheckBox::indicator:checked {
-    background-color: #E53E3E; /* Accent */
-    border: 1px solid #C53030;
-}
-QCheckBox::indicator:checked:hover {
-    background-color: #F56565;
-}
-
-/* GROUP BOX TITLES */
-QGroupBox {
-    font-weight: 600;
-    color: #2D3748;
-    margin-top: 8px;
-}
-QGroupBox:title {
-    subcontrol-origin: margin;
-    left: 6px;
-    padding: 2px 4px;
-}
-
-/* TOOLTIP */
-QToolTip {
-    background-color: #F7F8FC;
-    color: #1A202C;
-    border: 1px solid #D0D5DD;
-    border-radius: 6px;
-    padding: 4px 8px;
-}
-
-/* TIMELINE */
-TimelineWidget {
-    background-color: #2D3748;
-    color: #E2E8F0;
-}
-
-TimelineWidget QToolButton {
-    background-color: transparent;
-    color: #E2E8F0;
-}
-
-TimelineWidget QToolButton:hover {
-    background-color: #4A5568;
-}
-
-TimelineWidget QToolButton:checked {
-    background-color: #E53E3E;
-    color: white;
-}
-
-"""
-
-STYLE_SHEET_DARK = """
-* { color: #E2E8F0; font-family: Poppins, sans-serif; }
-QMainWindow, QDialog { background-color: #1F2937; }
-DraggableOverlay, PanelOverlay { background-color: rgba(31,41,55,0.92); border-radius: 12px; border: 1px solid #374151; }
-DraggableHeader { background-color: rgba(55,65,81,0.9); border-bottom: 1px solid rgba(75,85,99,0.6); border-top-left-radius: 12px; border-top-right-radius: 12px; }
-QToolButton { background: transparent; border: none; border-radius: 6px; padding: 5px; }
-QToolButton:hover { background-color: #374151; }
-QToolButton:checked { background-color: #EF4444; }
-QLineEdit, QDoubleSpinBox, QSpinBox, QComboBox { background-color: #111827; border: 1px solid #374151; border-radius: 4px; padding: 4px; color: #E5E7EB; }
-QLineEdit:focus, QDoubleSpinBox:focus, QSpinBox:focus, QComboBox:focus { border-color: #EF4444; background-color: #0B0F16; }
-QTreeView, QListWidget { background-color: transparent; border: none; }
-QTreeView::item, QListWidget::item { padding: 4px; border-radius: 4px; }
-QTreeView::item:hover, QListWidget::item:hover { background-color: #374151; }
-QTreeView::item:selected, QListWidget::item:selected { background-color: #EF4444; color: white; }
-QCheckBox { spacing: 6px; }
-QCheckBox::indicator { width: 16px; height: 16px; border-radius: 3px; }
-QCheckBox::indicator:unchecked { background-color: #111827; border: 1px solid #4B5563; }
-QCheckBox::indicator:unchecked:hover { background-color: #0B0F16; }
-QCheckBox::indicator:checked { background-color: #EF4444; border: 1px solid #B91C1C; }
-QCheckBox::indicator:checked:hover { background-color: #F87171; }
-QGroupBox { font-weight: 600; color: #E5E7EB; margin-top: 8px; }
-QGroupBox:title { subcontrol-origin: margin; left: 6px; padding: 2px 4px; }
-TimelineWidget { background-color: #111827; color: #D1D5DB; }
-TimelineWidget QToolButton { background: transparent; color: #D1D5DB; }
-TimelineWidget QToolButton:hover { background-color: #1F2937; }
-TimelineWidget QToolButton:checked { background-color: #EF4444; color: white; }
-QToolTip { background-color: #111827; color: #E5E7EB; border: 1px solid #374151; border-radius: 6px; padding: 4px 8px; }
-"""
 
 
 def build_stylesheet(params: dict) -> str:
@@ -282,67 +107,15 @@ QToolTip {{ background-color: {tip_bg}; color: {tip_text}; border: 1px solid {ti
 """
 
 
-def apply_stylesheet(app):
-    """Apply the application's stylesheet.
-
-    Reads QSettings 'ui/theme' to select light/dark theme.
-    """
+def apply_stylesheet(app, profile: UIProfile | None = None) -> None:
+    """Apply the application's stylesheet based on the given profile."""
     try:
-        from PySide6.QtCore import QSettings
-
-        s = QSettings("JaJa", "Macronotron")
-        ts = ThemeSettings.from_qsettings(s)
-        if ts.preset == "custom":
-            # Prefer explicit stored CSS, otherwise build from params
-            custom_css = s.value("ui/custom_stylesheet")
-            if not custom_css:
-                try:
-                    custom_css = build_stylesheet(ts.custom_params)
-                except Exception:
-                    logging.exception(
-                        "Failed to build custom stylesheet; falling back to light theme"
-                    )
-                    custom_css = STYLE_SHEET_LIGHT
-            app.setStyleSheet(str(custom_css))
-        else:
-            preset = ts.preset
-            if preset == "dark":
-                css = STYLE_SHEET_DARK
-            elif preset == "high contrast":
-                # No dedicated stylesheet; reuse dark for now
-                css = STYLE_SHEET_DARK
-            else:
-                css = STYLE_SHEET_LIGHT
-            app.setStyleSheet(css)
+        profile = profile or UIProfile.from_qsettings()
+        css = build_stylesheet(profile.theme.custom_params)
+        app.setStyleSheet(css)
         try:
-            app.setFont(QFont(str(ts.font_family or "Poppins"), 10))
+            app.setFont(QFont(str(profile.theme.font_family or "Poppins"), 10))
         except RuntimeError:
             logging.warning("Requested font not found, using system default.")
     except Exception:
-        logging.exception("Failed to apply theme from settings; using dark fallback")
-        app.setStyleSheet(STYLE_SHEET_DARK)
-        try:
-            app.setFont(QFont("Poppins", 10))
-        except RuntimeError:
-            logging.warning("Poppins font not found, using system default.")
-
-
-def get_theme_colors() -> dict[str, str]:
-    """Get current theme colors for non-stylesheet elements (e.g., QGraphicsScene)."""
-    from PySide6.QtCore import QSettings
-
-    s = QSettings("JaJa", "Macronotron")
-    theme = str(s.value("ui/theme", "dark")).lower()
-    if theme == "dark":
-        return {
-            "background": "#1F2937",
-            "text": "#E2E8F0",
-            "panel": "#111827",
-            "accent": "#EF4444",
-        }
-    return {
-        "background": "#E2E8F0",
-        "text": "#1A202C",
-        "panel": "#F7F8FC",
-        "accent": "#E53E3E",
-    }
+        logging.exception("Failed to apply theme from settings")

--- a/ui/ui_profile.py
+++ b/ui/ui_profile.py
@@ -96,13 +96,6 @@ class UIProfile:
     APP: str = "Macronotron"
 
     @classmethod
-    def default_dark(cls) -> "UIProfile":
-        p = cls()
-        p.theme.preset = "dark"
-        p.theme.font_family = "Poppins"
-        return p
-
-    @classmethod
     def from_qsettings(cls, s: Optional[QSettings] = None) -> "UIProfile":
         s = s or QSettings(cls.ORG, cls.APP)
         p = cls()
@@ -252,7 +245,7 @@ class UIProfile:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "UIProfile":
-        p = cls.default_dark() if not isinstance(data, dict) else cls()
+        p = cls()
         try:
             p.version = int(data.get("version", p.version))
         except Exception:
@@ -261,7 +254,6 @@ class UIProfile:
         tdata = data.get("theme")
         if isinstance(tdata, dict):
             t = ThemeSettings()
-            t.preset = str(tdata.get("preset", t.preset)).lower()
             t.font_family = str(tdata.get("font_family", t.font_family))
             if isinstance(tdata.get("custom_params"), dict):
                 t.custom_params.update(tdata["custom_params"])  # type: ignore[index]
@@ -332,5 +324,5 @@ class UIProfile:
                 data = load(f)
             return cls.from_dict(data if isinstance(data, dict) else {})
         except Exception:
-            # Fallback to default dark
-            return cls.default_dark()
+            # Fallback to defaults
+            return cls()

--- a/ui_profile.json
+++ b/ui_profile.json
@@ -1,7 +1,6 @@
 {
   "version": 1,
   "theme": {
-    "preset": "custom",
     "font_family": "Poppins",
     "custom_params": {
       "bg_color": "#E2E8F0",
@@ -35,7 +34,6 @@
       "checkbox_checked_border": "#C53030",
       "checkbox_checked_hover": "#F56565"
     },
-    "theme_file": null,
     "ORG": "JaJa",
     "APP": "Macronotron"
   },


### PR DESCRIPTION
## Résumé
- Simplification de `ThemeSettings` pour ne conserver que la police et les paramètres personnalisés.
- `UIProfile` et `apply_stylesheet` s'appuient désormais uniquement sur les paramètres personnalisés.
- Suppression de toute persistance `ui/theme` dans les réglages.

## Tests
- `pytest -q`
- `pylint core ui macronotron.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3587aef24832ba31c58da6e1f9b11