### PR TITLE
ui: apply stylesheet from profile

### DIFF
--- a/macronotron.py
+++ b/macronotron.py
@@ -6,12 +6,13 @@ from typing import List
 from PySide6.QtWidgets import QApplication
 from ui.main_window import MainWindow
 from ui.styles import apply_stylesheet
+from ui.settings_manager import load_active_profile
 
 
 def create_app(argv: List[str]) -> QApplication:
     """Crée (ou récupère) l'instance QApplication et applique le thème."""
     app = QApplication.instance() or QApplication(argv)
-    apply_stylesheet(app)
+    apply_stylesheet(app, load_active_profile())
     return app
 
 

--- a/ui/settings_manager.py
+++ b/ui/settings_manager.py
@@ -13,6 +13,15 @@ from ui.styles import apply_stylesheet, build_stylesheet
 from ui.ui_profile import UIProfile
 
 
+def load_active_profile() -> UIProfile:
+    """Charge le profil UI courant depuis le stockage persistant."""
+    try:
+        return UIProfile.from_qsettings(QSettings("JaJa", "Macronotron"))
+    except Exception:
+        logging.exception("Failed to load UIProfile; using default dark")
+        return UIProfile.default_dark()
+
+
 class SettingsManager:
     """Encapsulates the saving and restoring of UI settings (geometries, visibility)."""
 
@@ -503,7 +512,7 @@ class SettingsManager:
                 self.win.view.apply_menu_settings_main()
                 self.win.view.apply_menu_settings_quick()
                 self.win.timeline_widget.update()
-                apply_stylesheet(QApplication.instance())
+                apply_stylesheet(QApplication.instance(), load_active_profile())
             except Exception:
                 logging.exception("Apply settings failed")
 
@@ -851,6 +860,6 @@ class SettingsManager:
                     self.win.timeline_widget.update()
                 except Exception:
                     pass
-                apply_stylesheet(QApplication.instance())
+                apply_stylesheet(QApplication.instance(), prof)
             except Exception:
                 logging.exception("Failed to persist UIProfile from dialog")


### PR DESCRIPTION
## Summary
- apply global stylesheet based on a provided UIProfile
- centralize profile loading via `load_active_profile`
- ensure settings dialog refreshes styles using the active profile

## Testing
- `pytest -q`
- `pylint core ui macronotron.py`


------
https://chatgpt.com/codex/tasks/task_e_68a382651674832bae130d0bb009e0d4